### PR TITLE
[ADD] feat(PDF-attestation): New user actions to generate PDF attesta…

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -237,6 +237,7 @@ import {
 } from './metadata/schema-json-ld/schema-types/product/product-creative-work-schema-type';
 import { ProductDatasetSchemaType } from './metadata/schema-json-ld/schema-types/product/product-dataset-schema-type';
 import { PersonSchemaType } from './metadata/schema-json-ld/schema-types/Person/person-schema-type';
+import { PdfAttestationDownloadService } from './data/pdf-attestation-download.service';
 
 /**
  * When not in production, endpoint responses can be mocked for testing purposes
@@ -373,6 +374,7 @@ const PROVIDERS = [
   WorkflowStepStatisticsDataService,
   WorkflowOwnerStatisticsDataService,
   LoginStatisticsService,
+  PdfAttestationDownloadService,
 ];
 
 const SCHEMA_PROVIDERS = [

--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -38,4 +38,5 @@ export enum FeatureID {
   CanSubscribe = 'canSubscribeDso',
   ShowClaimItem = 'showClaimItem',
   CanCorrectItem = 'canCorrectItem',
+  CanDownloadPDFAttestation = 'canDownloadPDFAttestation',
 }

--- a/src/app/core/data/pdf-attestation-download.service.ts
+++ b/src/app/core/data/pdf-attestation-download.service.ts
@@ -1,0 +1,57 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { environment } from 'src/environments/environment';
+import { Observable, catchError, of } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { NotificationsService } from 'src/app/shared/notifications/notifications.service';
+import { saveAs } from 'file-saver';
+
+/**
+ * Service to generate a PDF attestation from the API.
+ */
+@Injectable()
+export class PdfAttestationDownloadService {
+
+    constructor(
+        private httpClient: HttpClient,
+        private notificationsService: NotificationsService,
+        private translationService: TranslateService
+    ){}
+
+    /**
+     * Generic method to make a HTTP GET call
+     */
+    private get(url: string) {
+        return this.httpClient.get(url, {
+            responseType: 'blob'
+        });
+    }
+
+    /**
+    * Calls the backend to generate an attestation based onb the uuid of the item.
+    *
+    * @param uuid: The item UUID.
+    * @return: An observable for the request's response.
+    */
+    public getPDFAttestationForUUID(uuid: string): Observable<Blob> {
+        return this.get(environment.rest.baseUrl + '/api/uclouvain/item/' + uuid + '/attestation');
+    }
+
+    /**
+    * Triggers a call to the backend API to recover the attestation for a specific item and downloads it on the client computer.
+    *
+    * @param uuid: The item UUID.
+    */
+    public triggerPDFAttestationDownload(uuid: string): void {
+        this.getPDFAttestationForUUID(uuid)
+            .pipe(catchError((error: any, caught: Observable<any>): Observable<any> => {
+                // Send error notification to client using the notification service
+                this.notificationsService.error(
+                    this.translationService.get('submission.workflow.generic.attestation.error.title'),
+                    this.translationService.get('submission.workflow.generic.attestation.error.content')
+                );
+                return of();
+            }))
+            .subscribe(response => saveAs(response, 'attestation.pdf'));
+    }
+}

--- a/src/app/shared/context-menu/context-menu-entry-type.ts
+++ b/src/app/shared/context-menu/context-menu-entry-type.ts
@@ -14,4 +14,5 @@ export enum ContextMenuEntryType {
   ItemVersion = 'itemversion',
   FullItem = 'fullitem',
   OrcidView = 'orcidview',
+  PdfAttestation = 'pdfattestation',
 }

--- a/src/app/shared/context-menu/context-menu.module.ts
+++ b/src/app/shared/context-menu/context-menu.module.ts
@@ -22,6 +22,7 @@ import { ItemVersionMenuComponent } from './item-version/item-version-menu.compo
 import { FullItemMenuComponent } from './full-item/full-item-menu.component';
 import { OrcidViewPageMenuComponent } from './orcid-view-page/orcid-view-page-menu.component';
 import { SharedModule } from '../shared.module';
+import { PDFAttestationMenuComponent } from './pdf-attestation/pdf-attestation-menu.component';
 
 const COMPONENTS = [
   BulkImportMenuComponent,
@@ -38,7 +39,8 @@ const COMPONENTS = [
   SubscriptionMenuComponent,
   ItemVersionMenuComponent,
   FullItemMenuComponent,
-  OrcidViewPageMenuComponent
+  OrcidViewPageMenuComponent,
+  PDFAttestationMenuComponent,
 ];
 
 const ENTRY_COMPONENTS = [
@@ -55,7 +57,8 @@ const ENTRY_COMPONENTS = [
   SubscriptionMenuComponent,
   ItemVersionMenuComponent,
   FullItemMenuComponent,
-  OrcidViewPageMenuComponent
+  OrcidViewPageMenuComponent,
+  PDFAttestationMenuComponent,
 ];
 
 const MODULE = [

--- a/src/app/shared/context-menu/pdf-attestation/pdf-attestation-menu.component.html
+++ b/src/app/shared/context-menu/pdf-attestation/pdf-attestation-menu.component.html
@@ -1,0 +1,5 @@
+<button *ngIf="isAuthorized$ | async" 
+        class="btn btn-info text-nowrap" 
+        (click)="generateAttestationDownloadURL()">
+        <i class="fa fa-download"></i> {{ "submission.workflow.generic.attestation.label" | translate }}
+</button>

--- a/src/app/shared/context-menu/pdf-attestation/pdf-attestation-menu.component.ts
+++ b/src/app/shared/context-menu/pdf-attestation/pdf-attestation-menu.component.ts
@@ -1,0 +1,67 @@
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+
+import { Observable, Subscription } from 'rxjs';
+
+import { DSpaceObject } from '../../../core/shared/dspace-object.model';
+import { AuthorizationDataService } from '../../../core/data/feature-authorization/authorization-data.service';
+import { ContextMenuEntryComponent } from '../context-menu-entry.component';
+import { DSpaceObjectType } from '../../../core/shared/dspace-object-type.model';
+import { rendersContextMenuEntriesForType } from '../context-menu.decorator';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { ContextMenuEntryType } from '../context-menu-entry-type';
+import { FeatureID } from 'src/app/core/data/feature-authorization/feature-id';
+import { PdfAttestationDownloadService } from 'src/app/core/data/pdf-attestation-download.service';
+
+@Component({
+  selector: 'ds-pdf-attestation-menu',
+  templateUrl: './pdf-attestation-menu.component.html'
+})
+@rendersContextMenuEntriesForType(DSpaceObjectType.ITEM, true)
+/**
+ * Display a button allowing to download a PDF attestation from the item view
+ */
+export class PDFAttestationMenuComponent extends ContextMenuEntryComponent implements OnInit, OnDestroy {
+
+    /**
+     * Whether or not the current user is authorized to edit the DSpaceObject
+     */
+    isAuthorized$: Observable<boolean>;
+
+    private subscriptions = new Subscription();
+
+    /**
+     * Initialize instance variables
+     *
+     * @param {DSpaceObject} injectedContextMenuObject
+     * @param {DSpaceObjectType} injectedContextMenuObjectType
+     * @param {AuthorizationDataService} authorizationService
+     * @param {NotificationsService} notificationService
+     * @param {PdfAttestationDownloadService} pdfAttestationDownloadService
+     */
+    constructor(
+        @Inject('contextMenuObjectProvider') protected injectedContextMenuObject: DSpaceObject,
+        @Inject('contextMenuObjectTypeProvider') protected injectedContextMenuObjectType: DSpaceObjectType,
+        private authorizationService: AuthorizationDataService,
+        private notificationService: NotificationsService,
+        private pdfAttestationDownloadService: PdfAttestationDownloadService,
+    ) {
+        super(injectedContextMenuObject, injectedContextMenuObjectType, ContextMenuEntryType.PdfAttestation);
+    }
+
+    ngOnInit() {
+        this.subscriptions.add(this.notificationService.claimedProfile.subscribe(() => {
+            this.isAuthorized$ = this.authorizationService.isAuthorized(FeatureID.CanDownloadPDFAttestation, this.contextMenuObject.self, undefined, false);
+        }));
+    }
+
+    ngOnDestroy(): void {
+        this.subscriptions.unsubscribe();
+    }
+
+    /**
+    * Called when the user click on the menu button. Triggers a download.
+    */
+    generateAttestationDownloadURL(){
+        this.pdfAttestationDownloadService.triggerPDFAttestationDownload(this.injectedContextMenuObject.uuid);
+    }
+}

--- a/src/app/shared/mydspace-actions/mydspace-actions.module.ts
+++ b/src/app/shared/mydspace-actions/mydspace-actions.module.ts
@@ -18,6 +18,7 @@ import { ItemActionsComponent } from './item/item-actions.component';
 import { PoolTaskActionsComponent } from './pool-task/pool-task-actions.component';
 import { WorkflowitemActionsComponent } from './workflowitem/workflowitem-actions.component';
 import { WorkspaceitemActionsComponent } from './workspaceitem/workspaceitem-actions.component';
+import { PdfAttestationActionComponent } from './pdf-attestation-action/pdf-attestation-action.component';
 
 const ENTRY_COMPONENTS = [
   ClaimedTaskActionsApproveComponent,
@@ -31,6 +32,7 @@ const DECLARATIONS = [
   ClaimedTaskActionsComponent,
   ClaimedTaskActionsLoaderComponent,
   ItemActionsComponent,
+  PdfAttestationActionComponent,
   PoolTaskActionsComponent,
   WorkflowitemActionsComponent,
   WorkspaceitemActionsComponent,

--- a/src/app/shared/mydspace-actions/pdf-attestation-action/pdf-attestation-action.component.html
+++ b/src/app/shared/mydspace-actions/pdf-attestation-action/pdf-attestation-action.component.html
@@ -1,0 +1,5 @@
+<button *ngIf="isAuthorized$ | async"
+        (click)="generateAttestationDownloadURL()"
+        class="btn btn-info mt-1 mb-3 ml-1" >
+    <i class="fa fa-download"></i> {{"submission.workflow.generic.attestation.label" | translate}}
+</button>

--- a/src/app/shared/mydspace-actions/pdf-attestation-action/pdf-attestation-action.component.ts
+++ b/src/app/shared/mydspace-actions/pdf-attestation-action/pdf-attestation-action.component.ts
@@ -1,0 +1,56 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Item } from 'src/app/core/shared/item.model';
+import { Observable, Subscription } from 'rxjs';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { FeatureID } from 'src/app/core/data/feature-authorization/feature-id';
+import { AuthorizationDataService } from 'src/app/core/data/feature-authorization/authorization-data.service';
+import { PdfAttestationDownloadService } from 'src/app/core/data/pdf-attestation-download.service';
+
+/**
+ * Button component that allows an authorized user to download a PDF attestation for a submission from the myDSpace page.
+ */
+@Component({
+    selector: 'ds-pdf-attestation-action',
+    templateUrl: './pdf-attestation-action.component.html',
+})
+export class PdfAttestationActionComponent implements OnInit, OnDestroy {
+
+    @Input() object: Item;
+
+    objectId: string;
+
+    isAuthorized$: Observable<boolean>;
+
+    private subscriptions = new Subscription();
+
+    public constructor(
+        private pdfAttestationDownloadService: PdfAttestationDownloadService,
+        private notificationsService: NotificationsService,
+        private authorizationService: AuthorizationDataService
+    ) {
+    }
+
+    ngOnInit(): void {
+        this.subscriptions.add(
+            this.notificationsService.claimedProfile.subscribe(() => {
+                this.isAuthorized$ = this.authorizationService.isAuthorized(FeatureID.CanDownloadPDFAttestation, this.object.self, undefined, false);
+            })
+        );
+        this.initDSOAttestationRoute(this.object.id);
+    }
+
+    ngOnDestroy(): void {
+        this.subscriptions.unsubscribe();
+    }
+
+    private initDSOAttestationRoute(itemID: string) {
+        this.objectId = itemID;
+    }
+
+    /**
+    * Called when the user click on the action button. Triggers a download.
+    */
+    generateAttestationDownloadURL() {
+        this.pdfAttestationDownloadService.triggerPDFAttestationDownload(this.objectId);
+    }
+}

--- a/src/app/shared/object-list/my-dspace-result-list-element/item-search-result/item-search-result-list-element-submission.component.html
+++ b/src/app/shared/object-list/my-dspace-result-list-element/item-search-result/item-search-result-list-element-submission.component.html
@@ -5,6 +5,7 @@
 <div class="row">
   <div [ngClass]="showThumbnails ? 'offset-3 offset-xl-2 pl-3' : ''">
     <ds-item-actions [object]="dso" (processCompleted)="reloadedObject.emit($event.reloadedObject)"></ds-item-actions>
+    <ds-pdf-attestation-action [object]="dso"></ds-pdf-attestation-action>
   </div>
 </div>
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6450,6 +6450,12 @@
 
   "submission.submit.title": "New submission",
 
+  "submission.workflow.generic.attestation.label": "Download attestation",
+
+  "submission.workflow.generic.attestation.error.title": "Something went wrong !",
+
+  "submission.workflow.generic.attestation.error.content": "Could not generate the PDF attestation for the given submission.",
+
   "submission.workflow.generic.delete": "Delete",
 
   "submission.workflow.generic.delete-help": "Select this option to discard this item. You will then be asked to confirm it.",
@@ -6593,6 +6599,8 @@
   "subscriptions.table.not-available-message": "The subscribed item has been deleted, or you don't currently have the permission to view it",
 
   "subscriptions.table.empty.message": "You do not have any subscriptions at this time. To subscribe to email updates for a Community or Collection, use the subscription button on the object's page.",
+
+  "thesis.page.titleprefix": "Thesis:",
 
   "thumbnail.default.alt": "Thumbnail Image",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -10791,7 +10791,14 @@
   // "submission.submit.title": "New submission",
   "submission.submit.title": "Nouvelle soumission",
 
+  // "submission.workflow.generic.attestation.label": "Download attestation"
+  "submission.workflow.generic.attestation.label": "Télécharger l'attestation",
 
+  // "submission.workflow.generic.attestation.error.title": "Something went wrong !",
+  "submission.workflow.generic.attestation.error.title": "Une erreur s'est produite !",
+
+  // "submission.workflow.generic.attestation.error.content": "Could not generate the PDF attestation for the given submission.",
+  "submission.workflow.generic.attestation.error.content": "Impossible de générer l'attestation PDF pour cette soumission.",
 
   // "submission.workflow.generic.delete": "Delete",
   "submission.workflow.generic.delete": "Supprimer",
@@ -11057,6 +11064,9 @@
   // TODO New key - Add a translation
   "subscriptions.table.empty.message": "You do not have any subscriptions at this time. To subscribe to email updates for a Community or Collection, use the subscription button on the object's page.",
 
+
+  // "thesis.page.titleprefix" : "Thesis:"
+  "thesis.page.titleprefix": "Mémoire:",
 
   // "thumbnail.default.alt": "Thumbnail Image",
   "thumbnail.default.alt": "Vignette d'image",


### PR DESCRIPTION
Adding new users actions to be able to download a PDF attestation from the Frontend.

+ New button in 'MyDspace' section, for items that have been archived, in order to download the attestation.
+ New action option on the detail view of an archived item that allows an admin or the submitter to download the attestation.