### PR TITLE
[ADD] feat(Action button): Accept without diffusion action button for manager.

### DIFF
--- a/src/app/shared/mydspace-actions/claimed-task/approve_no_diffusion/claimed-task-actions-approve-no-diffusion.component.html
+++ b/src/app/shared/mydspace-actions/claimed-task/approve_no_diffusion/claimed-task-actions-approve-no-diffusion.component.html
@@ -1,0 +1,38 @@
+<button type="button"
+        [className]="'btn btn-success'"
+        ngbTooltip="{{'submission.workflow.tasks.claimed.approve-no-diffusion_help' | translate}}"
+        [disabled]="processing$ | async"
+        (click)="openApproveModal(approveModal)">
+  <span *ngIf="processing$ | async"><i class='fas fa-circle-notch fa-spin'></i> {{'submission.workflow.tasks.generic.processing' | translate}}</span>
+  <span *ngIf="!(processing$ | async)"><i class="fa fa-thumbs-up"></i> {{'submission.workflow.tasks.claimed.approve-no-diffusion' | translate}}</span>
+</button>
+
+<ng-template #approveModal let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <h4 class="modal-title">{{'submission.workflow.tasks.claimed.approve-no-diffusion.reason.title' | translate}}</h4>
+    <button type="button"
+            class="close"
+            aria-label="Close"
+            (click)="d('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-info" role="alert">
+      {{'submission.workflow.tasks.claimed.approve-no-diffusion.reason.info' | translate}}
+    </div>
+    <form (ngSubmit)="submitTask();">
+      <textarea class="form-control"
+                [formControl]="approveForm"
+                rows="4"
+                placeholder="{{'submission.workflow.tasks.claimed.approve-no-diffusion.reason.placeholder' | translate}}"></textarea>
+      <button id="btn-chat"
+              class="btn btn-success btn-lg btn-block mt-3"
+              [disabled]="!approveForm.valid || (processing$ | async)"
+              type="submit">
+        <span *ngIf="processing$ | async"><i class='fas fa-circle-notch fa-spin'></i> {{'submission.workflow.tasks.generic.processing' | translate}}</span>
+        <span *ngIf="!(processing$ | async)">{{'submission.workflow.tasks.claimed.approve-no-diffusion.reason.submit' | translate}}</span>
+      </button>
+    </form>
+  </div>
+</ng-template>

--- a/src/app/shared/mydspace-actions/claimed-task/approve_no_diffusion/claimed-task-actions-approve-no-diffusion.component.ts
+++ b/src/app/shared/mydspace-actions/claimed-task/approve_no_diffusion/claimed-task-actions-approve-no-diffusion.component.ts
@@ -1,0 +1,83 @@
+import { Component, Injector, OnInit } from '@angular/core';
+import { rendersWorkflowTaskOption } from '../switcher/claimed-task-actions-decorator';
+import { ClaimedTaskActionsApproveComponent } from '../approve/claimed-task-actions-approve.component';
+import { RequestService } from 'src/app/core/data/request.service';
+import { SearchService } from 'src/app/core/shared/search/search.service';
+import { TranslateService } from '@ngx-translate/core';
+import { NotificationsService } from 'src/app/shared/notifications/notifications.service';
+import { Router } from '@angular/router';
+import { FormControl, Validators } from '@angular/forms';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { isNotEmpty } from 'src/app/shared/empty.util';
+
+export const WORKFLOW_TASK_OPTION_APPROVE_NO_DIFFUSION = 'submit_approve_no_diffusion';
+
+@rendersWorkflowTaskOption(WORKFLOW_TASK_OPTION_APPROVE_NO_DIFFUSION)
+@Component({
+  selector: 'ds-claimed-task-actions-approve-no-diffusion',
+  templateUrl: './claimed-task-actions-approve-no-diffusion.component.html',
+})
+/**
+ * This component renders a button used to accept a submission but with no diffusion.
+ * By 'no diffusion' we mean that all the bistreams won't be accessible to anyone except the admin.
+ * When the manager clicks on this button, it opens a modal that allows him to enter a reason explaining why he choose this option.
+ */
+export class ClaimedTaskActionsApproveNoDiffusionComponent extends ClaimedTaskActionsApproveComponent implements OnInit {
+  option = WORKFLOW_TASK_OPTION_APPROVE_NO_DIFFUSION;
+
+  // The form control that handles the reason of the validation with no diffusion.
+  public approveForm: FormControl;
+  // The initial value used to fill the field by default.
+  private initialValue: string;
+  public modalRef: NgbModalRef;
+
+  constructor(
+    protected injector: Injector,
+    protected router: Router,
+    protected notificationsService: NotificationsService,
+    protected translate: TranslateService,
+    protected searchService: SearchService,
+    protected requestService: RequestService,
+    private modalService: NgbModal
+  ){
+    super(injector, router, notificationsService, translate, searchService, requestService);
+  }
+
+  ngOnInit(): void {
+    // Try to retrieve the default form field value from the i18n config.
+    this.translate.get('submission.workflow.tasks.claimed.approve-no-diffusion.reason.default')
+      .subscribe(
+        (translation) => {
+          this.initialValue = isNotEmpty(translation) ? translation : '';
+          this.approveForm = new FormControl(this.initialValue, Validators.required);
+        }
+      );
+  }
+
+  /**
+   * Submit an approve option for the task.
+   */
+  submitTask(): void {
+    this.modalRef.close('Send Button');
+    super.submitTask();
+  }
+
+  /**
+   * Create the request body to approve the workflow task.
+   * Includes the reason given by the user.
+   */
+  createbody(): any {
+    const reason = this.approveForm.value;
+    return Object.assign(super.createbody(), { reason });
+  }
+
+  /**
+   * Open the form modal that allows the user to enter a reason for the validation without diffusion.
+   *
+   * @param content: Object containing the reference to the modal.
+   */
+  openApproveModal(content: any): void {
+    this.approveForm.reset(this.initialValue);
+    this.modalRef = this.modalService.open(content);
+  }
+}

--- a/src/app/shared/mydspace-actions/mydspace-actions.module.ts
+++ b/src/app/shared/mydspace-actions/mydspace-actions.module.ts
@@ -9,6 +9,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '../shared.module';
 import { ClaimedTaskActionsApproveComponent } from './claimed-task/approve/claimed-task-actions-approve.component';
+import { ClaimedTaskActionsApproveNoDiffusionComponent } from './claimed-task/approve_no_diffusion/claimed-task-actions-approve-no-diffusion.component';
 import { ClaimedTaskActionsRejectComponent } from './claimed-task/reject/claimed-task-actions-reject.component';
 import { ClaimedTaskActionsReturnToPoolComponent } from './claimed-task/return-to-pool/claimed-task-actions-return-to-pool.component';
 import { ClaimedTaskActionsEditMetadataComponent } from './claimed-task/edit-metadata/claimed-task-actions-edit-metadata.component';
@@ -21,6 +22,7 @@ import { WorkspaceitemActionsComponent } from './workspaceitem/workspaceitem-act
 
 const ENTRY_COMPONENTS = [
   ClaimedTaskActionsApproveComponent,
+  ClaimedTaskActionsApproveNoDiffusionComponent,
   ClaimedTaskActionsRejectComponent,
   ClaimedTaskActionsReturnToPoolComponent,
   ClaimedTaskActionsEditMetadataComponent,

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6543,6 +6543,20 @@
 
   "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
 
+  "submission.workflow.tasks.claimed.approve-no-diffusion": "Approve without diffusion",
+
+  "submission.workflow.tasks.claimed.approve-no-diffusion_help": "Approve but all the bitstreams will be in forbidden access.",
+
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.title": "Comment",
+
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.info": "Please enter a comment on why you choose to accept this item without diffusion.",
+
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.placeholder": "Add a comment",
+
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.submit": "Approve without diffusion",
+
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.default": "Diffusion of this thesis is not authorized by the institution.",
+
   "submission.workflow.tasks.claimed.edit": "Edit",
 
   "submission.workflow.tasks.claimed.edit_help": "Select this option to change the item's metadata.",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -10889,6 +10889,27 @@
   // "submission.workflow.tasks.claimed.approve_help": "If you have reviewed the item and it is suitable for inclusion in the collection, select \"Approve\".",
   "submission.workflow.tasks.claimed.approve_help": "Si vous avez bien révisé cet Item et qu'il peut être ajouté à la collection, sélectionner « Approuver ».",
 
+  // "submission.workflow.tasks.claimed.approve-no-diffusion": "Approve without diffusion",
+  "submission.workflow.tasks.claimed.approve-no-diffusion": "Approuver sans diffusion",
+
+  // "submission.workflow.tasks.claimed.approve-no-diffusion_help": "Approve but all the bitstreams will be in forbidden access."
+  "submission.workflow.tasks.claimed.approve-no-diffusion_help": "Approuve mais tous les fichiers attachés seront placés en accès interdit.",
+
+  // "submission.workflow.tasks.claimed.approve-no-diffusion.reason.title": "Comment",
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.title": "Commentaire",
+
+  // "submission.workflow.tasks.claimed.approve-no-diffusion.reason.info": "Please enter a comment on why you choose to accept this item without diffusion.",
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.info": "Veuillez entrer un commentaire qui explique pourquoi accepter cette soumission sans diffusion.",
+
+  // "submission.workflow.tasks.claimed.approve-no-diffusion.reason.placeholder": "Add a comment",
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.placeholder": "Ajouter un commentaire",
+
+  // "submission.workflow.tasks.claimed.approve-no-diffusion.reason.submit": "Approve without diffusion",
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.submit": "Approuver sans diffusion",
+
+  // "submission.workflow.tasks.claimed.approve-no-diffusion.reason.default": "Diffusion of this thesis is not authorized by the institution.",
+  "submission.workflow.tasks.claimed.approve-no-diffusion.reason.default": "La diffusion de ce mémoire n'est pas autorisée par l'institution.",
+
   // "submission.workflow.tasks.claimed.edit": "Edit",
   "submission.workflow.tasks.claimed.edit": "Éditer",
 


### PR DESCRIPTION
New action button that allows a manager to accept an item and restrict the access to it's bitstreams. When accepting the manager can enter a message justifying his choice. This message is kept in the item's metadata.