### PR TITLE
[FIX] feat(BUG): Object-List not loading

### DIFF
--- a/src/themes/uclouvain/app/shared/object-list/object-list.component.ts
+++ b/src/themes/uclouvain/app/shared/object-list/object-list.component.ts
@@ -15,7 +15,13 @@ import { PaginationService } from '../../../../../app/core/pagination/pagination
 @Component({
   selector: 'ds-object-list',
   styleUrls: ['../../../../../app/shared/object-list/object-list.component.scss', './object-list.component.scss'],
-  templateUrl: './object-list.component.html'
+  templateUrl: './object-list.component.html',
+  providers: [
+    {
+      provide: SEARCH_CONFIG_SERVICE,
+      useClass: SearchConfigurationService
+    }
+  ]
 })
 export class ObjectListComponent extends BaseComponent implements OnInit, OnDestroy {
 


### PR DESCRIPTION
Fixed the 'object-list' component not loading on some pages like 'Collections of this Community' or 'Other items from the same collection'. Added a missing provider definition in the 'Component' decorator to fix the problem.
