### PR TITLE
[UPD] feat(item-context-menu): Check for authorization on full item metadata view.

### DIFF
--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -40,4 +40,5 @@ export enum FeatureID {
   CanCorrectItem = 'canCorrectItem',
   CanCreateSubmission = 'canCreateSubmission',
   CanDownloadPDFAttestation = 'canDownloadPDFAttestation',
+  CanSeeFullItem = 'canSeeFullItem',
 }

--- a/src/app/shared/context-menu/full-item/full-item-menu.component.html
+++ b/src/app/shared/context-menu/full-item/full-item-menu.component.html
@@ -1,3 +1,3 @@
-<button *ngIf="!isSameView(contextMenuObject)" class="dropdown-item" [routerLink]="getItemFullPageRoute(contextMenuObject)"
+<button *ngIf="(isAuthorized$ | async) && !isSameView(contextMenuObject)" class="dropdown-item" [routerLink]="getItemFullPageRoute(contextMenuObject)"
         [innerHTML]="'context-menu.actions.show-all-metadata' | translate">
 </button>


### PR DESCRIPTION
Now, only manager/admin users will be able to see the full item view. If the user does not belong to one of those groups, he will simply not see the option in the context menu.