### PR TITLE
[UPD] feat(browse-by-date): Date browse component modification + i18n

### DIFF
--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -1635,7 +1635,7 @@
   "browse.comcol.by.promoter": "Promoteur",
 
   // "browse.comcol.by.dateissued": "By Issue Date",
-  "browse.comcol.by.dateissued": "Date de publication",
+  "browse.comcol.by.dateissued": "Date de défense",
 
   // "browse.comcol.by.ouname": "By Name",
   // TODO New key - Add a translation
@@ -1686,7 +1686,7 @@
   "browse.metadata.author": "Auteur",
 
   // "browse.metadata.dateissued": "Issue Date",
-  "browse.metadata.dateissued": "Date de publication",
+  "browse.metadata.dateissued": "Date de défense",
 
   // "browse.metadata.eqdatecreated": "Date Created",
   // TODO New key - Add a translation

--- a/src/themes/uclouvain/app/shared/starts-with/date/starts-with-date.component.html
+++ b/src/themes/uclouvain/app/shared/starts-with/date/starts-with-date.component.html
@@ -1,0 +1,34 @@
+<form class="w-100" [formGroup]="formData" (ngSubmit)="submitForm(formData.value)">
+    <div class="row">
+      <span class="col-12 font-weight-bold mb-1">
+        {{'browse.startsWith.jump' | translate}}
+      </span>
+      <div class="col-6 col-md-2">
+        <select id="year-select" class="form-control" (change)="setStartsWithYearEvent($event)" [attr.aria-label]="'browse.startsWith.choose_year.label' |translate">
+          <option [value]="-1" [selected]="!startsWithYear">
+            {{'browse.startsWith.choose_year' | translate}}
+          </option>
+          <option *ngFor="let option of startsWithOptions"
+                  [value]="option"
+                  [selected]="option === startsWithYear ? 'selected': null">
+            {{option}}
+          </option>
+        </select>
+      </div>
+      <!-- <div class="col-6 col-md-2">
+        <select id="month-select" class="form-control" (change)="setStartsWithMonthEvent($event)" [attr.aria-label]="'browse.startsWith.months.none.label' |translate">
+          <option *ngFor="let option of monthOptions"
+                  [value]="option"
+                  [selected]="option === startsWithMonth ? 'selected': null">
+            {{'browse.startsWith.months.' + option | translate}}
+          </option>
+        </select>
+      </div> -->
+      <!-- <div class="form-group input-group col-12 col-md-6 pt-1 pt-md-0">
+        <input class="form-control" placeholder="{{'browse.startsWith.type_date' | translate}}" [attr.aria-label]="'browse.startsWith.type_date.label' |translate" type="text" name="startsWith" formControlName="startsWith" [value]="getStartsWith() ? getStartsWith() : ''" />
+        <span class="input-group-append">
+          <button class="btn btn-primary" type="submit"><i class="fas fa-book-open"></i> {{'browse.startsWith.submit' | translate}}</button>
+        </span>
+      </div> -->
+    </div>
+  </form>

--- a/src/themes/uclouvain/app/shared/starts-with/date/starts-with-date.component.ts
+++ b/src/themes/uclouvain/app/shared/starts-with/date/starts-with-date.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { renderStartsWithFor, StartsWithType } from 'src/app/shared/starts-with/starts-with-decorator';
+import { StartsWithDateComponent as BaseComponent } from '../../../../../../app/shared/starts-with/date/starts-with-date.component';
+
+@Component({
+    selector: 'ds-starts-with-date',
+    styleUrls: ['../../../../../../app/shared/starts-with/date/starts-with-date.component.scss'],
+    templateUrl: './starts-with-date.component.html',
+})
+@renderStartsWithFor(StartsWithType.date)
+export class StartsWithDateComponent extends BaseComponent {
+}

--- a/src/themes/uclouvain/eager-theme.module.ts
+++ b/src/themes/uclouvain/eager-theme.module.ts
@@ -15,6 +15,7 @@ import { SharedBrowseByModule } from '../../app/shared/browse-by/shared-browse-b
 import { ResultsBackButtonModule } from '../../app/shared/results-back-button/results-back-button.module';
 import { ExploreModule } from '../../app/shared/explore/explore.module';
 import { FooterModule } from '../../app/footer/footer.module';
+import { StartsWithDateComponent } from './app/shared/starts-with/date/starts-with-date.component';
 
 /**
  * Add components that use a custom decorator to ENTRY_COMPONENTS as well as DECLARATIONS.
@@ -31,6 +32,7 @@ const DECLARATIONS = [
   HeaderNavbarWrapperComponent,
   NavbarComponent,
   FooterComponent,
+  StartsWithDateComponent,
 ];
 
 @NgModule({


### PR DESCRIPTION
-> Changed the date browse to only allow year selection (not month)
-> Changed translation of 'Date de publication' to 'Date de défense'