### PR TITLE
[UPD] feat(breadcrumbs) Hidden the communities && collection links in breadcrumb.

### DIFF
--- a/src/app/breadcrumbs/breadcrumbs.component.html
+++ b/src/app/breadcrumbs/breadcrumbs.component.html
@@ -4,7 +4,9 @@
             <ng-container
                     *ngTemplateOutlet="breadcrumbs?.length > 0 ? breadcrumb : activeBreadcrumb; context: {text: 'home.breadcrumbs', url: '/'}"></ng-container>
             <ng-container *ngFor="let bc of breadcrumbs; let last = last;">
-                <ng-container *ngTemplateOutlet="!last ? breadcrumb : activeBreadcrumb; context: bc"></ng-container>
+                <!-- We need to hide all breadcrumbs links to avoid pages like 'browse by collection' or 'browse by community'. -->
+                 <!-- So, we are just rendering the last element which is the active element. -->
+                <ng-container *ngTemplateOutlet="!last ? '' : activeBreadcrumb; context: bc"></ng-container>
             </ng-container>
         </ol>
     </nav>

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4155,6 +4155,8 @@
   "browse.metadata.faculty": "faculty",
   "browse.metadata.degree": "degree",
 
+  "browse.comcol.by.degree": "Degree",
+  "browse.comcol.by.faculty": "Faculty",
 
   "item.page.filesection.bitstream.download_url.tooltip": "Click here to copy the link that allows the promoter to download the bitstream content. <strong>For safety reason, please only share this link with a promoter in charge of the submission</strong>.",
   "item.page.filesection.bitstream.download_url.label": "Copy download link",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -13769,6 +13769,9 @@
   "browse.metadata.faculty": "faculté",
   "browse.metadata.degree": "diplôme",
 
+  "browse.comcol.by.degree": "Diplôme",
+  "browse.comcol.by.faculty": "Faculté",
+
   "item.page.filesection.bitstream.download_url.tooltip": "Cliquer ici pour copier le lien permettant au promoteur de télécharger le contenu du bitstream. <strong>Pour des raisons de sécurité, veuillez partager uniquement ce lien avec les promoteurs en charge de la soumission</strong>.",
   "item.page.filesection.bitstream.download_url.label": "Copier le lien de téléchargement",
 


### PR DESCRIPTION
To avoid confusion for the student, we removed elements from the breadcrumb. We removed the community and the collection link which led to 2 different browse pages. Those pages were really confusing and were clashing with the already existing 'browse' section of the navbar.