### PR TITLE
[FIX] feat(model-hidden): Field display && validation

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -42,7 +42,7 @@
           <!-- In case of not repeatable field with multiple values show empty space for all elements except the last -->
           <div *ngIf="(context?.index !== null && (!showErrorMessages || errorMessages.length === 0)) || (!hasHint && !showErrorMessages) ||
                   (!model.hideErrorMessages && showErrorMessages && !(!(model?.isModelOfNotRepeatableGroup) || model?.isModelOfNotRepeatableGroup && context?.index === context?.context?.groups?.length - 1))"
-               class="clearfix w-100 mb-2"></div>
+                [class.mb-2]="isVisible()" class="clearfix w-100"></div>
 
           <!-- In case of not repeatable field with multiple values show error message for the last element only -->
           <div

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -45,6 +45,7 @@ import {
   DynamicFormControlEvent,
   DynamicFormControlEventType,
   DynamicFormControlModel,
+  DynamicFormGroupModel,
   DynamicFormLayout,
   DynamicFormLayoutService,
   DynamicFormRelationService,
@@ -612,4 +613,19 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
     }
   }
 
+  /**
+   * Checks if the current model should be considered as visible by the user.
+   * This is used to render the margin dynamically. If the model is visible => render margin.
+   * This is useful to get rid of the useless margin in non visible blocks.
+   * 
+   * @returns True if at least one element is visible. If all hidden then return false.
+   */
+  isVisible(): boolean {
+    // Tow cases
+    //   1) If the model has a group property, check if any children is visible.
+    //   2) If the model has no group property, it means that it has no children : return its own hidden property.
+    return (this.model.group && isNotEmpty(this.model.group))
+      ? (this.model as DynamicFormGroupModel).group.some(el => !el.hidden)
+      : !this.model.hidden;
+  }
 }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.components.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.components.ts
@@ -294,6 +294,8 @@ export class DsDynamicRelationGroupModalComponent extends DynamicFormControlComp
     return this.formModel
       .map(row => (row as DynamicFormGroupModel).group)
       .reduce((previousValue, currentValue) => previousValue.concat(currentValue))
+      // Not visible form field should not prevent from submitting the form.
+      .filter(model => !model.hidden)
       .map(model => model as DsDynamicInputModel)
       .filter(model => !!model.validators && 'required' in model.validators);
   }


### PR DESCRIPTION
-> Hidden fields no longer block validation of a form.
-> Hidden fields no longer generate margin which was causing gaps between form fields.