### PR TITLE
[ADD] feat(submission): Allow help link for any form fields.

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -4,11 +4,15 @@
   [formGroup]="group"
   [ngClass]="[getClass('element', 'container'), getClass('grid', 'container')]">
 
-  <label *ngIf="!isCheckbox && hasLabel"
+  <div *ngIf="!isCheckbox && hasLabel"
          [id]="'label_' + model.id"
-         [for]="id"
-         [innerHTML]="(model.required && model.label) ? (model.label | translate) + ' *' : (model.label | translate)"
-         [ngClass]="[getClass('element', 'label'), getClass('grid', 'label')]"></label>
+         [ngClass]="[getClass('element', 'label'), getClass('grid', 'label')]">
+    <a *ngIf="model?.help" [href]="model.help" target="submission_help">
+      <i class="fa fa-solid fa-circle-question pr-1 text-info"></i>
+    </a>
+    <label *ngIf="model.label" class="mb-1" [for]="id" [innerHTML]="model.label | translate"></label>
+    <span *ngIf="model.required" class="pl-1 text-danger font-weight-bold">*</span>
+  </div>
   <div class="d-flex">
     <div class="flex-grow-1">
       <ng-container *ngTemplateOutlet="startTemplate?.templateRef; context: { $implicit: model };"></ng-container>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
@@ -38,6 +38,7 @@ export interface DsDynamicInputModelConfig extends DynamicInputModelConfig {
   toggleSecurityVisibility?: boolean;
   isModelOfNotRepeatableGroup?: boolean;
   hideHint?: boolean;
+  help?: string;
 }
 
 export class DsDynamicInputModel extends DynamicInputModel {
@@ -62,6 +63,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
   @serializable() toggleSecurityVisibility = true;
   @serializable() isModelOfNotRepeatableGroup = false;
   @serializable() hideHint: boolean = false;
+  @serializable() help?: string;
 
   constructor(config: DsDynamicInputModelConfig, layout?: DynamicFormControlLayout) {
     super(config, layout);
@@ -69,6 +71,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
     this.repeatable = config.repeatable;
     this.metadataFields = config.metadataFields;
     this.hint = config.hint;
+    this.help = config.help;
     this.readOnly = config.readOnly;
     this.disabled = config.readOnly;
     this.value = config.value;

--- a/src/app/shared/form/builder/models/form-field.model.ts
+++ b/src/app/shared/form/builder/models/form-field.model.ts
@@ -42,6 +42,12 @@ export class FormFieldModel {
     hints: string;
 
   /**
+   * The URL help link where to find a complete documentation for this field
+   */
+  @autoserialize
+    help: string;
+
+  /**
    * The label for this metadata field to display on form
    */
   @autoserialize

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -310,7 +310,7 @@ export abstract class FieldParser {
     }
   }
 
-  protected initModel(id?: string, label = true, labelEmpty = false, setErrors = true, hint = true) {
+  protected initModel(id?: string, label = true, labelEmpty = false, setErrors = true, hint = true, help = true) {
 
     const controlModel = Object.create(null);
 
@@ -340,6 +340,9 @@ export abstract class FieldParser {
     this.setLabel(controlModel, label);
     if (hint) {
       controlModel.hint = this.configData.hints || '&nbsp;';
+    }
+    if (help) {
+      controlModel.help = this.configData.help;
     }
     controlModel.placeholder = this.configData.label;
 


### PR DESCRIPTION
If the backend forms specify an help url link, a new icon is now visible before the field label. Cliking on the icon redirect the user to the corresponding link into new brower tab.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
