### PR TITLE
[ADD] feat(submission): Impove display of repeatable fields

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.html
@@ -21,7 +21,7 @@
           </div>
           <div class="d-flex flex-column w-100">
             <small
-              *ngIf="hasHint && !model.hideHint &&
+              *ngIf="showHint && hasHint && !model.hideHint &&
            (formBuilderService.hasArrayGroupValue(model) ||
             (
               (!model.repeatable

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -245,6 +245,7 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
   @Input() hasErrorMessaging = false;
   @Input() layout = null as DynamicFormLayout;
   @Input() model: any;
+  @Input() showHint = true;
   securityLevel: number;
   relationshipValue$: Observable<ReorderableRelationship>;
   isRelationship: boolean;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/array-group/dynamic-form-array.component.html
@@ -7,7 +7,7 @@
       <!-- Draggable Container -->
       <div cdkDropList cdkDropListLockAxis="y" (cdkDropListDropped)="moveSelection($event)">
         <!-- Draggable Items -->
-        <div *ngFor="let groupModel of model.groups; let idx = index"
+        <div *ngFor="let groupModel of model.groups; let idx = index; let lastGroup = last"
              role="group"
              [formGroupName]="idx"
              [ngClass]="[getClass('element', 'group'), getClass('grid', 'group')]"
@@ -30,6 +30,7 @@
                                              [class.d-none]="_model.hidden"
                                              [layout]="formLayout"
                                              [model]="_model"
+                                             [showHint]="lastGroup"
                                              [templates]="templates"
                                              [ngClass]="[getClass('element', 'host', _model), getClass('grid', 'host', _model)]"
                                              (dfBlur)="onBlur($event)"

--- a/src/app/shared/form/form.component.html
+++ b/src/app/shared/form/form.component.html
@@ -54,20 +54,24 @@
           </div>
         </div>
 
-        <div *ngIf="(!context.notRepeatable) && (index === (group.context.groups.length - 1) )" class="clearfix w-100"
+        <!--<div *ngIf="(!context.notRepeatable) && (index === (group.context.groups.length - 1) )" class="clearfix w-100"
              [class.pl-4]="!isInlineGroupForm"
-             [class.white-background]="isInlineGroupForm">
-          <div class="btn-group" role="group" aria-label="remove button">
-            <button type="button" role="button" class="ds-form-add-more btn btn-link"
-                title="{{'form.add' | translate}}"
-                attr.aria-label="{{'form.add' | translate}}"
-                [class.pl-0]="isInlineGroupForm"
-                [disabled]="isItemReadOnly(context, index)"
-                (click)="insertItem($event, group.context, group.context.groups.length)">
-              <span><i class="fas fa-plus"></i> {{'form.add' | translate}}</span>
-            </button>
-          </div>
-        </div>
+             [class.white-background]="isInlineGroupForm"> -->
+        <!-- always place the button in the DOM at the end of input field line (not below) -->
+         <div *ngIf="(!context.notRepeatable)">
+           <div class="btn-group" role="group" aria-label="add button">
+             <button type="button" role="button" class="ds-form-add-more btn btn-success"
+                 title="{{'form.add' | translate}}"
+                 attr.aria-label="{{'form.add' | translate}}"
+                 [class.pl-0]="isInlineGroupForm"
+                 [disabled]="isItemReadOnly(context, index)"
+                 [style.visibility]="(index === (group.context.groups.length - 1)) ? 'visible' : 'hidden'"
+                 (click)="insertItem($event, group.context, group.context.groups.length)">
+               <span><i class="fas fa-plus"></i></span>
+             </button>
+           </div>
+         </div>
+
 
         <!--Array with non repeatable items - Only discard button-->
         <div *ngIf="context.notRepeatable && context.showButtons && group.context.groups.length > 1"


### PR DESCRIPTION
For repeatable fields, the default behavior is to display a link below the fields group to add a new field. To save some scolling:
  * we move this button at the end of the field group line
  * we hide fields hint, only displays on the last fields group
  * change color of the button link to a gree real button.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>