### PR TITLE
[FIX] feat(submission): Fix dynamic relation modal behavior.

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.component.html
@@ -39,7 +39,7 @@
       <button *ngIf="!model.readOnly"
               type="button"
               class="btn btn-primary mr-2"
-              [disabled]="isMandatoryFieldEmpty()"
+              [disabled]="!isValidForm()"
               (click)="save()">
         <span *ngIf="item"><i class="fas fa-save"></i> {{'form.group.set' | translate}}</span>
         <span *ngIf="!item"><i class="fas fa-save"></i> {{'form.group.add' | translate}}</span>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.components.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/relation-group/modal/dynamic-relation-group-modal.components.ts
@@ -151,6 +151,12 @@ export class DsDynamicRelationGroupModalComponent extends DynamicFormControlComp
     return this.getMandatoryFieldModel().label;
   }
 
+  isValidForm() {
+    return (this.formRef)
+      ? this.formRef.formGroup.valid
+      : false;
+  }
+
   isMandatoryFieldEmpty() {
     const models = this.getMandatoryFields();
     return models.some(model => !model.value);
@@ -267,8 +273,7 @@ export class DsDynamicRelationGroupModalComponent extends DynamicFormControlComp
     if (!this.formRef.formGroup.valid) {
       this.formService.validateAllFormFields(this.formRef.formGroup);
       return;
-    }
-    if (!this.isMandatoryFieldEmpty()) {
+    } else {
       const item = this.buildChipItem();
       this.add.emit(item);
       this.closeModal();
@@ -304,8 +309,7 @@ export class DsDynamicRelationGroupModalComponent extends DynamicFormControlComp
     if (!this.formRef.formGroup.valid) {
       this.formService.validateAllFormFields(this.formRef.formGroup);
       return;
-    }
-    if (!this.isMandatoryFieldEmpty()) {
+    } else {
       const item = this.buildChipItem();
       this.edit.emit(item);
       this.closeModal();
@@ -324,7 +328,7 @@ export class DsDynamicRelationGroupModalComponent extends DynamicFormControlComp
     });
     this.formModel.forEach((row) => {
       const modelRow = row as DynamicFormGroupModel;
-      modelRow.group.forEach((control: DynamicInputModel) => {
+      modelRow.group.filter(control => !control.hidden).forEach((control: DynamicInputModel) => {
         const controlValue: any = (control?.value as any)?.value || control?.value || PLACEHOLDER_PARENT_METADATA;
         const controlAuthority: any = (control?.value as any)?.authority || null;
 


### PR DESCRIPTION
Using 'type-bind' fields into the dynamic relation modal frame cause some bugs when somes fields are hidden:
  * All required fields are used to validated the form, despite some fields are hiddden by type-bind
  * When multiple fields are same name (like authors.role), all values are evaulated despite the field is hidden.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>

