### PR TITLE
[ADD] feat(submission): Allow custom regex validation message

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/ds-dynamic-input.model.ts
@@ -159,7 +159,7 @@ export class DsDynamicInputModel extends DynamicInputModel {
   }
 
   hasSetting(name: string): boolean {
-    return name in this?.settings;
+    return this?.settings && name in this.settings;
   }
 
   getSetting<T>(name: string, type: Constructor<T> = String): T {

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -425,17 +425,14 @@ export abstract class FieldParser {
    */
   protected addPatternValidator(controlModel) {
     const validatorMatcher = this.configData.input.regex.match(REGEX_FIELD_VALIDATOR);
-    let regex;
-    if (validatorMatcher != null && validatorMatcher.length > 3) {
-      regex = new RegExp(validatorMatcher[2], validatorMatcher[3]);
-    } else {
-      regex = new RegExp(this.configData.input.regex);
-    }
+    const regex = (validatorMatcher != null && validatorMatcher.length > 3)
+      ? new RegExp(validatorMatcher[2], validatorMatcher[3])
+      : new RegExp(this.configData.input.regex);
+    const errorMessage = (controlModel?.settings && 'regexErrorMessage' in controlModel.settings)
+      ? controlModel.settings.regexErrorMessage
+      : 'error.validation.pattern';
     controlModel.validators = Object.assign({}, controlModel.validators, { pattern: regex });
-    controlModel.errorMessages = Object.assign(
-      {},
-      controlModel.errorMessages,
-      { pattern: 'error.validation.pattern' });
+    controlModel.errorMessages = Object.assign({}, controlModel.errorMessages, { pattern: errorMessage });
   }
 
   protected markAsRequired(controlModel) {


### PR DESCRIPTION
Allow to use backend "regexErrorMesssage" setting to specifiy a custom regex validation message for field controlled with a RegExp validator.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
