### PR TITLE
[FIX] feat(bitstream-download-url) Added missing followLink statement.

### DIFF
--- a/src/themes/uclouvain/app/item-page/simple/field-components/file-section/file-section.component.ts
+++ b/src/themes/uclouvain/app/item-page/simple/field-components/file-section/file-section.component.ts
@@ -26,7 +26,8 @@ export class FileSectionComponent extends BaseComponent {
       true,
       true,
       followLink('format'),
-      followLink('access')
+      followLink('access'),
+      followLink('download_url')
     );
   }
 }


### PR DESCRIPTION
## Description

A "followLink" statement was missing to embed "download_url" to the bundle request. This is required to see the direct download url on the item view for managers.