### PR TITLE
[UPD] feat(year): New year component behavior

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/year-picker/year-picker.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/year-picker/year-picker.component.html
@@ -15,7 +15,7 @@
             [name]="'year' | translate"
             [size]="4"
             [(ngModel)]="initialYear"
-            [value]="+model.value"
+            [value]="valueToDisplay"
             [invalid]="showErrorMessages"
             [placeholder]="yearPlaceholder | translate"
             [widthClass]="'four-digits'"

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/year-picker/year-picker.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/year-picker/year-picker.component.ts
@@ -2,7 +2,7 @@ import { OnInit, Input, Component, Output, EventEmitter } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { DynamicFormControlComponent, DynamicFormLayoutService, DynamicFormValidationService } from '@ng-dynamic-forms/core';
 import { DynamicDsYearPickerModel } from './year-picker.model';
-import { isUndefined } from 'src/app/shared/empty.util';
+import { isNotEmpty, isUndefined } from 'src/app/shared/empty.util';
 
 /**
  * A form field component representing a year.
@@ -29,6 +29,7 @@ export class DsYearPickerComponent extends DynamicFormControlComponent implement
     maxYear: number;
     minYear: number;
     yearPlaceholder: string = 'year';
+    valueToDisplay: number;
 
     constructor(protected layoutService: DynamicFormLayoutService,
         protected validationService: DynamicFormValidationService,
@@ -37,24 +38,56 @@ export class DsYearPickerComponent extends DynamicFormControlComponent implement
     }
 
     ngOnInit(): void {
-      const now = new Date();
-      this.initialYear = now.getFullYear();
+      const currentYear: number = new Date().getFullYear();
+      // If a year exists in the model use it has the year value.
       if (this.model.value !== null && this.isYearValid(this.model.value.toString())) {
-        this.initialYear = parseInt(this.model.value.toString(), 10);
-      } else if (this.model?.defaultValue) {
-        this.initialYear = this.model.defaultValue;
+        this.setModelValue(parseInt(this.model.value.toString(), 10));
+      // Else if no value found, see if we should use the current year.
+      } else if (this.model.useCurrentYear) {
+        this.setModelValue(currentYear);
       }
-      this.model.value = ''+this.initialYear;
-      this.change.emit(this.model.value);
 
-      this.maxYear = now.getUTCFullYear() + this.model.maxYearDelta;
-      if (this.initialYear && this.initialYear > this.maxYear) {
-        this.maxYear = this.initialYear;
-      }
-      this.minYear = now.getUTCFullYear() - this.model.minYearDelta;
-      if (this.initialYear && this.initialYear < this.minYear) {
-        this.minYear = this.initialYear;
-      }
+      this.processMaxYear(currentYear);
+      this.processMinYear(currentYear);
+    }
+
+    /**
+     * Set the max year: 
+     *  - If a delta is present, use it to process the max year based on the current year.
+     *  - If a delta is not present but a maxYear is present in config, use it.
+     *  - If nor delta or maxYear present, use default value.
+     * 
+     * @param currentYear The current year as number used to process the max year.
+     */
+    processMaxYear(currentYear: number): void {
+      this.maxYear = isNotEmpty(this.model.maxYearDelta) 
+        ? (currentYear + this.model.maxYearDelta)
+        : (isNotEmpty(this.model.maxYear) ? this.model.maxYear : 2199);
+    }
+
+    /**
+     * Set the min year: 
+     *  - If a delta is present, use it to process the min year based on the current year.
+     *  - If a delta is not present but a minYear is present in config, use it.
+     *  - If nor delta or minYear present, use default value.
+     * 
+     * @param currentYear The current year as number used to process the min year.
+     */
+    processMinYear(currentYear: number): void {
+      this.minYear = isNotEmpty(this.model.minYearDelta) 
+        ? (currentYear - this.model.minYearDelta)
+        : (isNotEmpty(this.model.minYear) ? this.model.minYear : 1000);
+    }
+
+    /** 
+     * Sets the model value to the given number
+     * 
+     * @param value The value to set the model to.
+     */
+    setModelValue(value: number | string): void {
+      this.model.value = ''+value;
+      this.change.emit(this.model.value);
+      this.valueToDisplay = parseInt(this.model.value);
     }
 
     onBlur($event: any): void {
@@ -63,8 +96,7 @@ export class DsYearPickerComponent extends DynamicFormControlComponent implement
 
     onChange(event: any): void {
         if (this.isYearValid(event.value)){
-            this.model.value = event.value;
-            this.change.emit(event.value);
+            this.setModelValue(event.value);
         }
     }
 
@@ -76,8 +108,8 @@ export class DsYearPickerComponent extends DynamicFormControlComponent implement
      * @return True if the year is defined and does not contain letters. False if not.
      */
     isYearValid(year: string) {
-        // 1XXX to 20XX are valid
-        let isValidData = /^(1[\d]{3}|20[\d]{2})$/.test(year);
+        // 1XXX to 21XX are valid
+        let isValidData = /^(1[\d]{3}|2[0-1][\d]{2})$/.test(year);
         return !isUndefined(year) && isValidData;
     }
 }

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/year-picker/year-picker.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/year-picker/year-picker.model.ts
@@ -13,18 +13,25 @@ export interface DynamicDsYearPickerModelConfig extends DynamicDsDatePickerModel
     metadataValue: MetadataValue;
     minYearDelta: number;
     maxYearDelta: number;
-    defaultValue: number;
+    minYear: number;
+    maxYear: number;
+    useCurrentYear: boolean;
 }
 
 export class DynamicDsYearPickerModel extends DynamicDsDatePickerModel {
     @serializable() readonly type: string = DYNAMIC_FORM_CONTROL_TYPE_DSYEARPICKER;
     @serializable() minYearDelta: number;
     @serializable() maxYearDelta: number;
-    @serializable() defaultValue: number = new Date().getFullYear();
+    @serializable() minYear: number;
+    @serializable() maxYear: number;
+    @serializable() useCurrentYear: boolean = false;
 
     constructor(config: DynamicDsYearPickerModelConfig, layout?: DynamicFormControlLayout) {
       super(config, layout);
-      this.minYearDelta = config?.minYearDelta || 100;
-      this.maxYearDelta = config?.maxYearDelta || 2;
+      this.minYearDelta = config?.minYearDelta;
+      this.maxYearDelta = config?.maxYearDelta;
+      this.minYear = config?.minYear;
+      this.maxYear = config?.maxYear;
+      this.useCurrentYear = config?.useCurrentYear;
     }
 }

--- a/src/app/shared/form/builder/parsers/field-parser.ts
+++ b/src/app/shared/form/builder/parsers/field-parser.ts
@@ -34,7 +34,7 @@ import {
 import { FormFieldModel } from '../models/form-field.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { RelationshipOptions } from '../models/relationship-options.model';
-import { setLayout } from './parser.utils';
+import { getSetting, setLayout } from './parser.utils';
 import { ParserOptions } from './parser-options';
 import { ParserType } from './parser-type';
 
@@ -428,9 +428,7 @@ export abstract class FieldParser {
     const regex = (validatorMatcher != null && validatorMatcher.length > 3)
       ? new RegExp(validatorMatcher[2], validatorMatcher[3])
       : new RegExp(this.configData.input.regex);
-    const errorMessage = (controlModel?.settings && 'regexErrorMessage' in controlModel.settings)
-      ? controlModel.settings.regexErrorMessage
-      : 'error.validation.pattern';
+    const errorMessage = getSetting(controlModel, 'regexErrorMessage') || 'error.validation.pattern';
     controlModel.validators = Object.assign({}, controlModel.validators, { pattern: regex });
     controlModel.errorMessages = Object.assign({}, controlModel.errorMessages, { pattern: errorMessage });
   }

--- a/src/app/shared/form/builder/parsers/parser.utils.ts
+++ b/src/app/shared/form/builder/parsers/parser.utils.ts
@@ -22,3 +22,41 @@ export function setLayout(model: any, controlLayout: string, controlLayoutConfig
     model.layout[controlLayout][controlLayoutConfig] = model.layout[controlLayout][controlLayoutConfig].concat(` ${style}`);
   }
 }
+
+
+/**
+ * Retrieves a specific setting from a model configuration setting and optionally formats it.
+ *
+ * @param config the model configuration containing the `settings` property to search within.
+ * @param key The key of the setting to retrieve from `data.settings`.
+ * @param format Optional format to apply to the setting's value. Supported formats:
+ *    - `Number`: Converts the value to a number.
+ *    - `String`: Converts the value to a string.
+ *    - `Boolean`: Converts the value to a boolean.
+ *    - `Date`: Converts the value to a Date object.
+ * @returns {any} The formatted setting value, the raw value if no format is specified,
+ *    or `undefined` if the `key` does not exist in `data.settings` or if `data` is invalid.
+ *
+ *  - If `data` or `data.settings` is not defined, the function returns `undefined`.
+ *  - If the `key` is not found within `data.settings`, the function returns `undefined`.
+ *  - If a `format` is specified but formatting fails (e.g., invalid date), the function logs an error
+ *    and returns `undefined`.
+ */
+export function getSetting(config: any, key: string, format?: any): any {
+  if (!config || !config.settings || !(key in config.settings)) {
+    return undefined;
+  }
+  const value = config.settings[key];
+  try {
+    switch (format) {
+      case Number: return Number(value);
+      case String: return String(value);
+      case Boolean: return Boolean(String(value).toLowerCase() === 'true');
+      case Date: return new Date(value);
+      default: return value;
+    }
+  } catch (error) {
+    console.error("Setting format error:", error);
+    return undefined;
+  }
+}

--- a/src/app/shared/form/builder/parsers/year-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/year-field-parser.ts
@@ -1,6 +1,7 @@
 import { DynamicDsYearPickerModel, DynamicDsYearPickerModelConfig } from '../ds-dynamic-form-ui/models/year-picker/year-picker.model';
 import { FormFieldMetadataValueObject } from '../models/form-field-metadata-value.model';
 import { FieldParser } from './field-parser';
+import { getSetting } from './parser.utils';
 
 /**
  * Parser for the 'YearPickerComponent'.
@@ -11,6 +12,12 @@ export class YearFieldParser extends FieldParser {
         const inputYearModelConfig: DynamicDsYearPickerModelConfig = this.initModel(null, false, true);
         inputYearModelConfig.legend = this.configData.label;
         inputYearModelConfig.disabled = inputYearModelConfig.readOnly;
+        inputYearModelConfig.useCurrentYear = getSetting(this.configData, 'useCurrentYearAsDefault', Boolean) || false;
+        inputYearModelConfig.minYearDelta = getSetting(this.configData, 'minYearDelta', Number);
+        inputYearModelConfig.maxYearDelta = getSetting(this.configData, 'maxYearDelta', Number);
+        inputYearModelConfig.minYear = getSetting(this.configData, 'minYear', Number);
+        inputYearModelConfig.maxYear = getSetting(this.configData, 'maxYear', Number);
+
         this.setValues(inputYearModelConfig as any, fieldValue);
         return new DynamicDsYearPickerModel(inputYearModelConfig);
     }


### PR DESCRIPTION
Updated the behavior of the year component to be configurable through the backend. We can define 'settings' in the backend configuration that will be used to configured the field:
- 'useCurrentYearAsDefault' is a boolean to set if we want a default value for the field (in which case we use the current year).
- 'minYearDelta' is the delta to process the minimum value of the field (currentYear - minDelta).
- 'maxYearDelta' is the delta to process the maximum value of the field (currentYear + maxDelta).
- 'minYear', only active if no 'maxYearDelta', sets the minYear.
- 'maxYear', only active if no 'minYearDelta', sets the maxYear.

Authored-By: Michaël Pourbaix <michael.pourbaix@uclouvain.be>