### PR TITLE
[FIX] feat(view): Fix MasterThesis display

### DIFF
--- a/src/app/shared/form/chips/chips.component.ts
+++ b/src/app/shared/form/chips/chips.component.ts
@@ -28,6 +28,7 @@ import {
 import { isNotEmpty } from '../../empty.util';
 import { Chips } from './models/chips.model';
 import { ChipsItem } from './models/chips-item.model';
+import { PLACEHOLDER_PARENT_METADATA } from '../builder/ds-dynamic-form-ui/ds-dynamic-form-constants';
 
 
 const TOOLTIP_TEXT_LIMIT = 21;
@@ -197,9 +198,10 @@ export class ChipsComponent implements OnChanges {
     // For master-thesis publication, try to display the degree code related to an author.
     let checkedFieldNames = ['dc.contributor.author', 'masterthesis.degree.code']
     if (checkedFieldNames.every(v => chip.item.hasOwnProperty(v) && isNotEmpty(chip.item[v]))) {
-      return chip.item['masterthesis.degree.code'];
+      return (chip.item['masterthesis.degree.code'].value !== PLACEHOLDER_PARENT_METADATA)
+        ? chip.item['masterthesis.degree.code'].value
+        : null;
     }
-
     return null;
   }
 

--- a/src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component.scss
+++ b/src/app/shared/metadata-field-wrapper/metadata-field-wrapper.component.scss
@@ -1,6 +1,6 @@
 :host {
   .simple-view-element {
-    margin-bottom: 15px;
+    // margin-bottom: 15px;
   }
   .simple-view-element-header {
     font-size: 1.25rem;

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1900,6 +1900,7 @@
   "item.page.filesection.format": "Format:",
   "item.page.filesection.name": "Name:",
   "item.page.filesection.size": "Size:",
+  "item.page.identifier": "Identifier",
   "item.page.journal.search.title": "Articles in this journal",
   "item.page.link.full": "Full item page",
   "item.page.link.simple": "Simple item page",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -5778,6 +5778,9 @@
   // "item.page.filesection.size": "Size:",
   "item.page.filesection.size": "Taille:",
 
+  // "item.page.identifier": "Identifier",
+  "item.page.identifier": "Identifiant",
+
   // "item.page.journal.search.title": "Articles in this journal",
   "item.page.journal.search.title": "Articles dans cette revue",
 

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/item-pages/master-thesis-page.component.html
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/item-pages/master-thesis-page.component.html
@@ -69,20 +69,25 @@
         <dl class="d-flex flex-column" style="height: 100%">
             <dt>{{ "item.page.uri" | translate }}</dt>
             <dd><ds-metadata-uri-values [mdValues]="object?.allMetadata(['dc.identifier.uri'])" [separator]="' ; '"></ds-metadata-uri-values></dd>
+            <ng-container *ngIf="(isUserAdmin | async) && isNotEmpty(externalIdentifiers)">
+                <dt>{{ "item.page.identifier" | translate }}</dt>
+                <dd>
+                    <span *ngFor="let identifier of externalIdentifiers | keyvalue" class="badge badge-secondary mr-1">
+                        <i class="fa-solid fa-tag mr-1"></i>
+                        {{ identifier | masterThesisIdentifierSerialization }}
+                    </span>
+                </dd>
+            </ng-container>
             <ng-container *ngIf="object.hasMetadata('masterthesis.faculty.code')">
                 <dt>{{ "item.page.faculty" | translate }}</dt>
                 <dd><ds-master-thesis-faculty-badges [object]="object"></ds-master-thesis-faculty-badges></dd>
             </ng-container>
             <dt>{{ "item.page.date" | translate }}</dt>
             <dd>{{ dsoDate }}</dd>
-            <dt>{{ "item.page.subject" | translate }}</dt>
-            <dd><ds-tag-item-page-field [item]="object" [fields]="['dc.subject']"></ds-tag-item-page-field></dd>
-            <!-- <ng-container *ngIf="object.hasMetadata('dc.type')">
-                <dt>{{ "item.page.document-type" | translate }}</dt>
-                <dd *ngFor="let docType of object?.allMetadata('dc.type')">
-                    {{ docType.value | translate }}
-                </dd>
-            </ng-container> -->
+            <ng-container *ngIf="object.hasMetadata('dc.subject')">
+                <dt>{{ "item.page.subject" | translate }}</dt>
+                <dd><ds-tag-item-page-field [item]="object" [fields]="['dc.subject']"></ds-tag-item-page-field></dd>
+            </ng-container>
             <ng-container *ngIf="object.firstMetadataValue('dc.language.iso-639-2') as language">
                 <dt>{{ "item.page.language" | translate }}</dt>
                 <dd>{{ "languages.iso-639-2."+language | translate }}</dd>

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/item-pages/master-thesis-page.component.scss
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/item-pages/master-thesis-page.component.scss
@@ -35,7 +35,7 @@ aside.additional-metadata {
       font-size: .8rem;
     }
     dd {
-      margin-bottom: 1rem;
+      margin-bottom: 1.5rem;
     }
   }
 }

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/item-pages/master-thesis-page.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/item-pages/master-thesis-page.component.ts
@@ -4,9 +4,40 @@ import { Context } from '../../../../../../app/core/shared/context.model';
 import { listableObjectComponent } from '../../../../../../app/shared/object-collection/shared/listable-object/listable-object.decorator';
 import { ItemComponent } from '../../../../../../app/item-page/simple/item-types/shared/item.component';
 import { DSpaceObjectType } from '../../../../../../app/core/shared/dspace-object-type.model';
+import { isNotEmpty } from '../../../../../../app/shared/empty.util';
+import { RouteService } from '../../../../../../app/core/services/route.service';
+import { Router } from '@angular/router';
+import { RoleService } from '../../../../../../app/core/roles/role.service';
+import { Observable } from 'rxjs';
+import { RoleType } from '../../../../../../app/core/roles/role-types';
+
+
+/** How to find and extract publication identifiers
+ *  For each entry we need to define 3 keys:
+ *    - field: the metadata field name where to find the identifier
+ *    - labelFn: a function to get/extract the identifier label. This function will receive the identifier value as param.
+ *    - valueFn: a function to get/extract the identifier value. This function will receive the identifier value as param.
+ *               If the extracted value is `null` (or empty), identifier will not be extracted.
+ *               If the extracted value isn't a `string`, the value will not be displayed (only the label in this case).
+ */
+const identifiersExtractors = [
+  {
+    field: 'dc.identifier.fedora',
+    labelFn: () => 'fedora',
+    valueFn: (v: string) => v
+  }, {
+    field: 'dc.identifier.other',
+    labelFn: (v: string) =>  v.match(/^([^:]+)::/)?.[1].toLowerCase() || 'other',
+    valueFn: (v: string) => v.match(/::(.*)/)?.[1] || v
+  }, {
+    field: 'dcterms.provenance',
+    labelFn: () => 'cataretro',
+    valueFn: (v: string) => v.toLowerCase() === 'cataretro' ? true : null,
+  }
+];
+
 
 /** Component to render 'MasterThesis' entity type for detailed view */
-
 @listableObjectComponent('MasterThesis', ViewMode.StandalonePage, Context.Any, 'uclouvain')
 @Component({
   selector: 'ds-master-thesis',
@@ -18,9 +49,41 @@ export class MasterThesisPageComponent extends ItemComponent {
   protected readonly DspaceObjectType = DSpaceObjectType;
   dateFormat = 'yyyy-MM-dd HH:mm:ss';
   dsoDate: string;
+  isUserAdmin: Observable<boolean>;
+  externalIdentifiers: { [key: string]: any } = {};
 
+  protected readonly isNotEmpty = isNotEmpty;
+
+  /**
+   * Constructor
+   * @param routeService RouteService
+   * @param router       Router
+   * @param roleService  RoleService
+   */
+  constructor(
+    protected routeService: RouteService,
+    protected router: Router,
+    protected roleService: RoleService,
+  ) {
+    super(routeService, router);
+  }
+
+  /** OnInit hook */
   ngOnInit() {
     super.ngOnInit();
+    this.isUserAdmin = this.roleService.checkRole(RoleType.Admin);
     this.dsoDate = this.object.firstMetadataValue('dc.date.issued');
+
+    // Load legacy identifiers
+    identifiersExtractors.forEach(({ field, labelFn, valueFn }) => {
+      this.object.allMetadataValues(field).forEach(mv => {
+        const value = valueFn(mv);
+        if (isNotEmpty(value)) {
+          this.externalIdentifiers[labelFn(mv)] = value;
+        }
+      });
+    });
   }
+
+
 }

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/master-thesis.module.ts
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/master-thesis.module.ts
@@ -12,6 +12,7 @@ import { MasterThesisListElementComponent } from './item-list-elements/master-th
 import { MasterThesisSearchResultListElementComponent } from './search-result-list-elements/master-thesis-search-result-list-element.component';
 import { MasterThesisFacultyBadgesComponent } from './item-widgets/master-thesis-faculty-badges.component';
 import { SharedThemeModule } from '../../../shared-theme.module';
+import { MasterThesisIdentifierPipe } from './pipes/master-thesis-identifier.pipe';
 
 const ENTRY_COMPONENTS = [];
 
@@ -23,7 +24,8 @@ const DECLARATIONS = [
   MasterThesisPageComponent,
   MasterThesisListElementComponent,
   MasterThesisSearchResultListElementComponent,
-  MasterThesisFacultyBadgesComponent
+  MasterThesisFacultyBadgesComponent,
+  MasterThesisIdentifierPipe
 ];
 
 @NgModule({

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/pipes/master-thesis-identifier.pipe.ts
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/pipes/master-thesis-identifier.pipe.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { isNotEmpty } from '../../../../../../app/shared/empty.util';
+
+@Pipe({
+  name: 'masterThesisIdentifierSerialization',
+})
+export class MasterThesisIdentifierPipe implements PipeTransform {
+  transform(identifier: { key: string, value: any }, separator: string = '::'): string {
+    let output = identifier.key;
+    if (typeof identifier.value === 'string' && isNotEmpty(identifier.value)) {
+      output += separator + identifier.value
+    }
+    return output;
+  }
+}

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/search-result-list-elements/master-thesis-search-result-list-element.component.html
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/search-result-list-elements/master-thesis-search-result-list-element.component.html
@@ -21,7 +21,7 @@
            class="lead item-list-title dont-break-out"></a>
         <div *ngIf="linkType == linkTypes.None" class="lead item-list-title dont-break-out" [innerHTML]="dsoTitle"></div>
         <!-- AUTHORS, PROMOTERS =================================== -->
-        <div class="flex-grow-1">
+        <div class="flex-grow-1 my-2">
             <div *ngIf="dso.allMetadataValues(['dc.contributor.author']).length > 0" class="item-list-authors">
                 <span class="mr-2">{{ 'item.page.author' | translate }}:</span>
                 <span class="text-muted">
@@ -47,19 +47,24 @@
                 </span>
             </div>
         </div>
-        <ul class="list-inline list-inline-with-divider m-0 small">
-            <li *ngIf="accessCondition">
+        <!-- ADDITIONAL METADATA ================================== -->
+        <div class="d-flex">
+            <ul class="list-inline list-inline-with-divider m-0 small">
+                <li *ngIf="dsoDate">
+                    <i class="far fa-calendar mr-2"></i>{{ dsoDate }}
+                </li>
+                <li *ngIf="dso.hasMetadata('masterthesis.faculty.code')">
+                    <ds-master-thesis-faculty-badges [object]="dso"></ds-master-thesis-faculty-badges>
+                </li>
+                <li *ngIf="(userIsAdmin | async) && isCataretro">
+                    <span class="badge badge-secondary text-all-small-caps">
+                        <i class="fa-solid fa-scroll mr-1"></i>cataretro
+                    </span>
+                </li>
+            </ul>
+            <div *ngIf="accessCondition && accessCondition.name !== 'unknown'" class="ml-auto">
                 <ds-access-conditions [accessConditions]="[accessCondition]"></ds-access-conditions>
-            </li>
-            <li *ngIf="dsoDate">
-                <i class="far fa-calendar mr-2"></i>{{ dsoDate }}
-            </li>
-            <!-- <li *ngIf="dsoLanguage && dsoLanguage !== 'other'">
-                <i class="fas fa-language mr-2"></i>{{ 'languages.iso-639-2.'+dsoLanguage | translate }}
-            </li> -->
-            <li *ngIf="dso.hasMetadata('masterthesis.faculty.code')">
-                <ds-master-thesis-faculty-badges [object]="dso"></ds-master-thesis-faculty-badges>
-            </li>
-        </ul>
+            </div>
+        </div>
     </div>
 </div>

--- a/src/themes/uclouvain/app/entity-groups/master-thesis-entity/search-result-list-elements/master-thesis-search-result-list-element.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/master-thesis-entity/search-result-list-elements/master-thesis-search-result-list-element.component.ts
@@ -2,12 +2,17 @@ import { Component, OnInit } from '@angular/core';
 import { ItemSearchResultListElementComponent } from '../../../shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component';
 import { ViewMode } from '../../../../../../app/core/shared/view-mode.model';
 import { listableObjectComponent } from '../../../../../../app/shared/object-collection/shared/listable-object/listable-object.decorator';
-import { isEmpty, isNotEmpty } from '../../../../../../app/shared/empty.util';
+import { isEmpty } from '../../../../../../app/shared/empty.util';
 import { getFirstSucceededRemoteDataWithNotEmptyPayload } from '../../../../../../app/core/shared/operators';
 import {
   AccessStatusObject
 } from '../../../../../../app/shared/object-collection/shared/badges/access-status-badge/access-status.model';
 import { AccessConditionObject } from '../../../../../../app/core/submission/models/access-condition.model';
+import { Observable } from 'rxjs';
+import { RoleType } from '../../../../../../app/core/roles/role-types';
+import { TruncatableService } from '../../../../../../app/shared/truncatable/truncatable.service';
+import { DSONameService } from '../../../../../../app/core/breadcrumbs/dso-name.service';
+import { RoleService } from '../../../../../../app/core/roles/role.service';
 
 @listableObjectComponent('MasterThesisSearchResult', ViewMode.ListElement)
 @Component({
@@ -23,8 +28,16 @@ export class MasterThesisSearchResultListElementComponent extends ItemSearchResu
   dsoLanguage: string;
   dsoDegreeLabels: string[];
   accessCondition: AccessConditionObject;
+  userIsAdmin: Observable<boolean>;
+  isCataretro = false;
 
-  protected readonly isNotEmpty = isNotEmpty;
+  constructor(
+    protected truncatableService: TruncatableService,
+    public dsoNameService: DSONameService,
+    private roleService: RoleService
+  ) {
+    super(truncatableService, dsoNameService);
+  }
 
   ngOnInit() {
     super.ngOnInit();
@@ -41,5 +54,7 @@ export class MasterThesisSearchResultListElementComponent extends ItemSearchResu
           this.accessCondition = Object.assign(new AccessConditionObject(), {id: 0, name: access.status});
         });
     }
+    this.userIsAdmin = this.roleService.checkRole(RoleType.Admin);
+    this.isCataretro = this.dso.allMetadataValues("dcterms.provenance").some(mv => mv === 'cataretro');
   }
 }

--- a/src/themes/uclouvain/app/item-page/simple/field-components/specific-field/tags/item-page-tag-fields.component.ts
+++ b/src/themes/uclouvain/app/item-page/simple/field-components/specific-field/tags/item-page-tag-fields.component.ts
@@ -9,9 +9,9 @@ import { isNotEmpty } from '../../../../../../../../app/shared/empty.util';
     <ng-container *ngVar="item?.allMetadata(fields) as tags">
         <div *ngIf="isNotEmpty(tags)" class="item-page-field">
             <ds-metadata-field-wrapper [label]="label | translate">
-                <ul class="list-unstyled">
+                <ul class="list-unstyled m-0">
                     <li *ngFor="let tag of tags" class="d-inline mr-2">
-                        <span class="badge badge-secondary">
+                        <span class="badge badge-secondary mt-1">
                             <i *ngIf="showIcon" class="{{ icon }} mr-1"></i>
                             {{ tag.value }}
                         </span>
@@ -20,7 +20,10 @@ import { isNotEmpty } from '../../../../../../../../app/shared/empty.util';
             </ds-metadata-field-wrapper>
         </div>
     </ng-container>
-  `
+  `,
+  styles: [
+    '.badge { max-width: 100%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }'
+  ]
 })
 export class ItemPageTagFieldsComponent {
 

--- a/src/themes/uclouvain/styles/_uclouvain.scss
+++ b/src/themes/uclouvain/styles/_uclouvain.scss
@@ -49,7 +49,12 @@ ul.list-inline-with-divider {
     display: inline-block;
     &:not(:last-child):after{
       content: '|';
-      margin: 0 1rem;
+      margin: 0 .5rem;
     }
   }
+}
+
+
+.text-all-small-caps {
+  font-variant: all-small-caps;
 }


### PR DESCRIPTION
* Search results
  - Moves access type badge on the right to have a better alignement
  - Display `cataretro` tag (only for admin)

* Detail page
  - Fixes some padding/margin problem
  - Fixes long keywords overflow
  - Adds identifiers display (onyl for admin)

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
