### PR TITLE
[UPD] feat(search-result) New display for search results.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -5,6 +5,13 @@ rest:
   nameSpace: /server
 ui:
   ssl: false
+
+item:
+  showAccessStatuses: true
+
+browseBy:
+  showThumbnails: false
+
 themes:
   - name: uclouvain
     headTags:

--- a/src/app/core/shared/item.model.ts
+++ b/src/app/core/shared/item.model.ts
@@ -161,7 +161,7 @@ export class Item extends DSpaceObject implements ChildHALResource, HandleObject
    * Method that returns as which type of object this object should be rendered
    */
   getRenderTypes(): (string | GenericConstructor<ListableObject>)[] {
-    const entityType = this.firstMetadataValue('dspace.entity.type');
+    const entityType = this.entityType || this.firstMetadataValue('dspace.entity.type');
     if (isEmpty(entityType)) {
       return super.getRenderTypes();
     }

--- a/src/app/item-page/item-page-routing-paths.ts
+++ b/src/app/item-page/item-page-routing-paths.ts
@@ -14,7 +14,7 @@ export function getItemModuleRoute() {
  * @param item  The item to retrieve the route for
  */
 export function getItemPageRoute(item: Item) {
-  const type = item.firstMetadataValue('dspace.entity.type');
+  const type = item.entityType || item.firstMetadataValue('dspace.entity.type');
   let url = item.uuid;
 
   if (isNotEmpty(item.metadata) && isNotEmpty(item.metadata['cris.customurl'])) {

--- a/src/app/shared/mydspace-actions/claimed-task/claimed-task-actions.component.html
+++ b/src/app/shared/mydspace-actions/claimed-task/claimed-task-actions.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngVar="(actionRD$ | async)?.payload as workflowAction">
-  <div class="mt-1 mb-3 space-children-mr">
+  <div class="mt-1 space-children-mr">
     <ds-claimed-task-actions-loader *ngFor="let option of workflowAction?.options"
                                     [item]="item"
                                     [option]="option"
@@ -9,7 +9,7 @@
     </ds-claimed-task-actions-loader>
 
     <button class="btn btn-primary workflow-view" ngbTooltip="{{'submission.workflow.generic.view-help' | translate}}"
-      [routerLink]="[getWorkflowItemViewRoute(workflowitem)]">
+      [routerLink]="[getItemPageRoute(item)]">
       <i class="fa fa-info-circle"></i> {{"submission.workflow.generic.view" | translate}}
     </button>
   </div>

--- a/src/app/shared/mydspace-actions/item/item-actions.component.html
+++ b/src/app/shared/mydspace-actions/item/item-actions.component.html
@@ -1,4 +1,4 @@
-<button class="btn btn-primary mt-1 mb-3"
+<button class="btn btn-primary mt-1"
             ngbTooltip="{{'submission.workflow.generic.view-help' | translate}}"
             [routerLink]="[itemPageRoute]">
   <i class="fa fa-info-circle"></i> {{"submission.workflow.generic.view" | translate}}

--- a/src/app/shared/mydspace-actions/mydspace-actions.ts
+++ b/src/app/shared/mydspace-actions/mydspace-actions.ts
@@ -26,6 +26,7 @@ import { SearchService } from '../../core/shared/search/search.service';
 import { NotificationOptions } from '../notifications/models/notification-options.model';
 import { NotificationsService } from '../notifications/notifications.service';
 import { MyDSpaceActionsServiceFactory } from './mydspace-actions-service.factory';
+import { getItemPageRoute } from 'src/app/item-page/item-page-routing-paths';
 
 export interface MyDSpaceActionsResult {
   result: boolean;
@@ -63,6 +64,8 @@ export abstract class MyDSpaceActionsComponent<T extends DSpaceObject, TService 
   protected objectDataService: TService;
 
   protected subscription: Subscription;
+
+  protected readonly getItemPageRoute = getItemPageRoute;
 
   /**
    * Initialize instance variables

--- a/src/app/shared/mydspace-actions/pool-task/pool-task-actions.component.html
+++ b/src/app/shared/mydspace-actions/pool-task/pool-task-actions.component.html
@@ -1,4 +1,4 @@
-<button type="button" class="btn btn-info mt-1 mb-3"
+<button type="button" class="btn btn-info mt-1"
   ngbTooltip="{{'submission.workflow.tasks.pool.claim_help' | translate}}" [disabled]="(processing$ | async)"
   (click)="claim()">
   <span *ngIf="(processing$ | async)"><i class='fas fa-circle-notch fa-spin'></i>
@@ -6,8 +6,8 @@
   <span *ngIf="(processing$ | async) !== true"><i class="fas fa-hand-paper"></i> {{'submission.workflow.tasks.pool.claim' |
     translate}}</span>
 </button>
-<button class="btn btn-primary workflow-view ml-1 mt-1 mb-3" data-test="view-btn"
+<button class="btn btn-primary workflow-view ml-1 mt-1" data-test="view-btn"
   ngbTooltip="{{'submission.workflow.generic.view-help' | translate}}"
-  [routerLink]="[getWorkflowItemViewRoute(workflowitem)]">
+  [routerLink]="[getItemPageRoute(item)]">
   <i class="fa fa-info-circle"></i> {{"submission.workflow.generic.view" | translate}}
 </button>

--- a/src/app/shared/mydspace-actions/workflowitem/workflowitem-actions.component.html
+++ b/src/app/shared/mydspace-actions/workflowitem/workflowitem-actions.component.html
@@ -1,5 +1,7 @@
-<button class="btn btn-primary workflow-view mt-1 mb-3" data-test="view-btn"
+<ng-container *ngVar="(object?.item | async) as item">
+  <button class="btn btn-primary workflow-view mt-1" data-test="view-btn"
         ngbTooltip="{{'submission.workspace.generic.view-help' | translate}}"
-        [routerLink]="[getWorkflowItemViewRoute(object)]">
-  <i class="fa fa-info-circle"></i> {{"submission.workspace.generic.view" | translate}}
-</button>
+        [routerLink]="[getItemPageRoute(item.payload)]">
+    <i class="fa fa-info-circle"></i> {{"submission.workspace.generic.view" | translate}}
+  </button>
+</ng-container>

--- a/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
+++ b/src/app/shared/mydspace-actions/workspaceitem/workspaceitem-actions.component.html
@@ -1,13 +1,14 @@
 <div class="space-children-mr">
 
-  <button class="btn btn-primary workflow-view mt-1 mb-3" data-test="view-btn"
-    ngbTooltip="{{'submission.workspace.generic.view-help' | translate}}"
-    [attr.aria-label]="'submission.workspace.generic.view-help' | translate"
-    [routerLink]="[getWorkspaceItemViewRoute(object)]">
-    <i class="fa fa-info-circle"></i> {{"submission.workspace.generic.view" | translate}}
-  </button>
+  <ng-container *ngVar="(object?.item | async) as item">
+    <button class="btn btn-primary workflow-view mt-1" data-test="view-btn"
+            ngbTooltip="{{'submission.workspace.generic.view-help' | translate}}"
+            [routerLink]="[getItemPageRoute(item.payload)]">
+      <i class="fa fa-info-circle"></i> {{"submission.workspace.generic.view" | translate}}
+    </button>
+  </ng-container>
 
-  <a class="btn btn-primary mt-1 mb-3 edit-btn" id="{{'edit_' + object.id}}"
+  <a class="btn btn-primary mt-1 edit-btn" id="{{'edit_' + object.id}}"
    *ngIf="(canEditItem$ | async)"
     ngbTooltip="{{'submission.workflow.generic.edit-help' | translate}}"
     [attr.aria-label]="'submission.workflow.generic.edit-help' | translate"
@@ -15,7 +16,7 @@
     <i class="fa fa-edit"></i> {{'submission.workflow.generic.edit' | translate}}
   </a>
 
-  <button type="button" id="{{'delete_' + object.id}}" class="btn btn-danger mt-1 mb-3"
+  <button type="button" id="{{'delete_' + object.id}}" class="btn btn-danger mt-1"
     *ngIf="(canEditItem$ | async)"
     ngbTooltip="{{'submission.workflow.generic.delete-help' | translate}}"
     [attr.aria-label]="'submission.workflow.generic.delete-help' | translate"

--- a/src/app/shared/object-collection/shared/badges/badges.component.ts
+++ b/src/app/shared/object-collection/shared/badges/badges.component.ts
@@ -43,6 +43,11 @@ export class BadgesComponent {
   @Input() showAccessStatus = false;
 
   /**
+   * Whether or not to show the entity type of the object
+   */
+  @Input() displayType = true;
+
+  /**
    * Returns whether or not this context is a MyDSpace status context
    */
   get isMyDSpaceStatus(): boolean {

--- a/src/app/shared/object-collection/shared/badges/themed-badges.component.ts
+++ b/src/app/shared/object-collection/shared/badges/themed-badges.component.ts
@@ -20,8 +20,9 @@ export class ThemedBadgesComponent extends ThemedComponent<BadgesComponent> {
   @Input() object: DSpaceObject;
   @Input() context: Context;
   @Input() showAccessStatus = false;
+  @Input() displayType = true;
 
-  protected inAndOutputNames: (keyof BadgesComponent & keyof this)[] = ['object', 'context', 'showAccessStatus'];
+  protected inAndOutputNames: (keyof BadgesComponent & keyof this)[] = ['object', 'context', 'showAccessStatus', 'displayType'];
 
   protected getComponentName(): string {
     return 'BadgesComponent';

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -618,6 +618,9 @@ export class SearchComponent implements OnDestroy, OnInit {
         ) as any,
       ];
     }
+    if (this.appConfig.item.showAccessStatuses) {
+      followLinks.push(followLink<Item>('accessStatus', { isOptional: true }));
+    }
 
     if (this.configuration === 'supervision') {
       followLinks.push(followLink<WorkspaceItem>('supervisionOrders', { isOptional: true }) as any);

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -4529,7 +4529,7 @@
 
   "mydspace.status.mydspaceArchived": "Archived",
 
-  "mydspace.status.mydspaceValidation": "Validation",
+  "mydspace.status.mydspaceValidation": "Awating validation",
 
   "mydspace.status.mydspaceWaitingController": "Waiting for reviewer",
 
@@ -9160,6 +9160,29 @@
   "search.filters.accessType.restricted": "restricted",
   "search.filters.accessType.administrator": "closed",
   "search.filters.accessType.embargo": "embargo",
+
+  // -- Publication types
+  "publication.type.journal-article.heading": "Journal Article",
+  "publication.type.book.heading": "Book",
+  "publication.type.book-part.heading": "Book Chapter",
+  "publication.type.working-paper.heading": "Working Paper",
+  "publication.type.report.heading": "Report",
+  "publication.type.patent.heading": "Patent",
+  "publication.type.conference-speech.heading": "Conference Speech",
+  "publication.type.dissertation.heading": "Dissertation",
+  "publication.type.unknown.heading": "Unknown type",
+
+  "item.entity-type.publication": "Publication",
+  "item.entity-type.orgunit": "OrgUnit",
+  "item.entity-type.person": "Person",
+  "item.entity-type.journal": "Journal",
+  "item.entity-type.unknown": "Unknown Type",
+
+  // ETAL ToolTip
+  "search.result.publication.authors.etal.tooltip": "This publication contains additional authors to those displayed here. See full item details for a complete list.",
+
+  // -- EMPTY TITLE PLACEHOLDER
+  "publication.list.element.title.placeholder": "Unkown title",
 
   // --- LANGUAGES ---
   "languages.iso-639-2.dut": "Dutch",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -14126,6 +14126,55 @@
   "search.filters.accessType.administrator": "accès interdit",
   "search.filters.accessType.embargo": "accès embargo",
 
+  // -- Publication types --
+  // "publication.type.journal-article.heading": "Journal Article",
+  "publication.type.journal-article.heading": "Article de périodique",
+
+  // "publication.type.book.heading": "Book",
+  "publication.type.book.heading": "Monographie",
+
+  // "publication.type.book-part.heading": "Book Chapter",
+  "publication.type.book-part.heading": "Contribution à un ouvrage collectif",
+
+  // "publication.type.working-paper.heading": "Working Paper",
+  "publication.type.working-paper.heading": "Document de travail",
+
+  // "publication.type.report.heading": "Report",
+  "publication.type.report.heading": "Rapport",
+
+  // "publication.type.patent.heading": "Patent",
+  "publication.type.patent.heading": "Brevet",
+
+  // "publication.type.conference-speech.heading": "Conference Speech",
+  "publication.type.conference-speech.heading": "Communication à un colloque",
+
+  // "publication.type.dissertation.heading": "Dissertation",
+  "publication.type.dissertation.heading": "Thèse",
+
+  // "publication.type.unknown.heading": "Unknown type",
+  "publication.type.unknown.heading": "Type inconnu",
+
+  // "item.entity-type.publication": "Publication",
+  "item.entity-type.publication": "Publication",
+
+  // "item.entity-type.orgunit": "OrgUnit",
+  "item.entity-type.orgunit": "Oganisation",
+
+  // "item.entity-type.person": "Person",
+  "item.entity-type.person": "Personne",
+
+  // "item.entity-type.journal": "Journal",
+  "item.entity-type.journal": "Journal",
+
+  // "item.entity-type.unknown": "Unknown Type",
+  "item.entity-type.unknown": "Type inconnu",
+
+  // ETAL ToolTip
+  "search.result.publication.authors.etal.tooltip": "Cette publication contient des auteurs additionnels à ceux affiché ici. Voir les détails de la publication pour une liste complète.",
+
+  // -- EMPTY TITLE PLACEHOLDER
+  "publication.list.element.title.placeholder": "Titre inconnu",
+
   // --- LANGUAGES ---
   "languages.iso-639-2.dut": "Néérlandais",
   "languages.iso-639-2.eng": "Anglais",

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/item-list-elements/publication-list-elements.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/item-list-elements/publication-list-elements.component.ts
@@ -1,0 +1,23 @@
+import { Component } from "@angular/core";
+import { Context } from "src/app/core/shared/context.model";
+import { Item } from "src/app/core/shared/item.model";
+import { ViewMode } from "src/app/core/shared/view-mode.model";
+import { listableObjectComponent } from "src/app/shared/object-collection/shared/listable-object/listable-object.decorator";
+import { AbstractListableElementComponent } from "src/app/shared/object-collection/shared/object-collection-element/abstract-listable-element.component";
+
+
+@listableObjectComponent('Publication', ViewMode.ListElement, Context.Search, 'uclouvain')
+@Component({
+  selector: 'ds-publication-list-element',
+  template: `<ds-publication-search-result-list-element-wrapper
+              [showLabel]="showLabel"
+              [showThumbnails]="showThumbnails"
+              [object]="{ indexableObject: object, hitHighlights: {} }" 
+              [linkType]="linkType">
+            </ds-publication-search-result-list-element-wrapper>`,
+})
+/**
+ * Component for displaying a list element for an item of type 'Publication'.
+ */
+export class PublicationListElementComponent extends AbstractListableElementComponent<Item> {
+}

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/publication.module.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/publication.module.ts
@@ -1,0 +1,40 @@
+import { NgModule } from '@angular/core';
+import { PublicationListElementComponent } from './item-list-elements/publication-list-elements.component';
+import { PublicationSearchResultListElementComponent } from './search-result-list-elements/publication-search-result/publication-search-result-list-element.component';
+import { SharedThemeModule } from 'src/themes/uclouvain/shared-theme.module';
+import { ItemSharedModule } from 'src/app/item-page/item-shared.module';
+import { ItemPageModule } from 'src/app/item-page/item-page.module';
+import { ContextMenuModule } from 'src/app/shared/context-menu/context-menu.module';
+import { ResultsBackButtonModule } from 'src/app/shared/results-back-button/results-back-button.module';
+import { SharedModule } from 'src/app/shared/shared.module';
+import { AuthorFormatDisplayComponent } from './specific-field/author-format-display.component';
+import { PublicationSearchResultWrapperComponent } from './search-result-list-elements/publication-search-result/publicaton-search-result-wrapper.component.html/publication-search-result-wrapper.component';
+import { ItemListPreviewComponent } from '../../shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component';
+
+const ENTRY_COMPONENTS = [];
+
+const DECLARATIONS = [
+  ...ENTRY_COMPONENTS,
+  PublicationListElementComponent,
+  PublicationSearchResultWrapperComponent,
+  PublicationSearchResultListElementComponent,
+  ItemListPreviewComponent,
+  AuthorFormatDisplayComponent,
+];
+
+@NgModule({
+  imports: [
+    SharedModule,
+    ResultsBackButtonModule,
+    ContextMenuModule,
+    ItemPageModule,
+    ItemSharedModule,
+    SharedThemeModule,
+  ],
+  declarations: DECLARATIONS,
+  providers: [
+    ...ENTRY_COMPONENTS.map((component) => ({provide: component}))
+  ],
+})
+export class PublicationModule {
+}

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/custom-type-badge/custom-type-badge.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/custom-type-badge/custom-type-badge.component.ts
@@ -1,0 +1,73 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Item } from 'src/app/core/shared/item.model';
+import { hasValue, isNotEmpty } from 'src/app/shared/empty.util';
+import { PUBLICATION_TYPES_MAPPING } from '../../type-label-mapping';
+import { DSpaceObject } from 'src/app/core/shared/dspace-object.model';
+import { getResourceTypeValueFor } from 'src/app/core/cache/object-cache.reducer';
+
+@Component({
+    selector: 'ds-custom-type-badge',
+    template: `<span class='badge text-muted font-weight-bold py-1 px-2' *ngIf='entityType || publicationType'>
+        <ng-container *ngIf='isNotEmpty(entityType)'> {{ entityType | translate }} </ng-container>
+        <ng-container *ngIf='isNotEmpty(publicationType)'>
+            <ng-container *ngIf='isNotEmpty(entityType)'> / </ng-container>
+            {{ parsePublicationType(publicationType) | translate }}
+        </ng-container>
+    </span>`,
+    styles: ['span {font-size: 0.8rem; line-height: 1.5; box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px;}']
+})
+export class CustomTypeBadgeComponent implements OnInit {
+    @Input() object: DSpaceObject;
+    @Input() displayEntityType: boolean = true;
+
+    protected entityType: string = undefined;
+    protected publicationType: string = undefined;
+
+    protected readonly isNotEmpty = isNotEmpty;
+
+    ngOnInit(): void {
+        if (isNotEmpty(this.object)) {
+            (this.object instanceof Item) ? this.typeFromItem(this.object): this.typeFromRenderedType(this.object);
+        }
+    }
+
+    /**
+     * Retrieve the types for an item.
+     * @param object The item to extract the type for.
+     */
+    typeFromItem(item: Item) {
+        let entityType = item.entityType.toLowerCase();
+        this.entityType = this.displayEntityType ? (entityType + '.listelement.badge'): undefined;
+        if (entityType === 'publication') {
+            this.publicationType = this.object.firstMetadataValue('dc.type.maintype');
+        }
+    }
+
+    /**
+     * Retrieve the literal string for a DSpace object.
+     * @param object The object to extract the type for.
+     */
+    typeFromRenderedType(object: DSpaceObject): void {
+        const renderTypes = object.getRenderTypes();
+        if (isNotEmpty(renderTypes.length)) {
+            const renderType = renderTypes[0];
+            if (renderType instanceof Function) {
+                const resourceTypeValue = getResourceTypeValueFor(object.type);
+                this.entityType = (hasValue(resourceTypeValue))
+                    ? `${resourceTypeValue.toLowerCase()}.listelement.badge`
+                    : `${renderType.name.toLowerCase()}.listelement.badge`;
+            } else {
+                    this.entityType = `${renderType.toLowerCase()}.listelement.badge`;
+            }
+        }
+        this.entityType = 'item.entity-type.unknown';
+    }
+
+    // Used to translate a publication type to a label that can be displayed.
+    parsePublicationType(type: string): string {
+        if (type.includes('text::')) {
+            return PUBLICATION_TYPES_MAPPING[type] ?? type.split('text::')[1];
+        }
+        return type;
+    }
+}

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publication-search-result-list-element.component.html
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publication-search-result-list-element.component.html
@@ -1,0 +1,25 @@
+<div class="d-flex">
+    <div class="d-flex flex-column w-100">
+        <!-- Item type and access status if available -->
+        <div class="mb-2 w-100">
+            <ds-themed-badges [object]="item" [showAccessStatus]="true" [context]="context" [displayType]="false"/>
+        </div>
+        <!-- TITLE ==================================================== -->
+        <a *ngIf="linkType != linkTypes.None"
+           [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'"
+           [attr.rel]="(linkType == linkTypes.ExternalLink) ? 'noopener noreferrer' : null"
+           [routerLink]="[itemPageRoute]"
+           [innerHTML]="itemTitle"
+           class="lead item-list-title dont-break-out"></a>
+        <div *ngIf="linkType == linkTypes.None" class="lead item-list-title dont-break-out" [innerHTML]="itemTitle"></div>
+        <!-- AUTHORS && SPECIFIC METADATA FOR TYPE =================================== -->
+        <div class="flex-grow-1 mb-1">
+            <div class="item-list-authors">
+                <ds-author-format-display [item]="item" />
+            </div>
+            <div class="font-italic text-muted">
+                [PLACE THE ITEM CITATION HERE]
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publication-search-result-list-element.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publication-search-result-list-element.component.ts
@@ -1,0 +1,43 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { TranslateService } from "@ngx-translate/core";
+import { Context } from "src/app/core/shared/context.model";
+import { Item } from "src/app/core/shared/item.model";
+import { getFirstSucceededRemoteDataWithNotEmptyPayload } from "src/app/core/shared/operators";
+import { AccessConditionObject } from "src/app/core/submission/models/access-condition.model";
+import { getItemPageRoute } from "src/app/item-page/item-page-routing-paths";
+import { CollectionElementLinkType } from "src/app/shared/object-collection/collection-element-link.type";
+import { AccessStatusObject } from "src/app/shared/object-collection/shared/badges/access-status-badge/access-status.model";
+
+@Component({
+  selector: 'ds-publication-search-result-list-element',
+  templateUrl: './publication-search-result-list-element.component.html',
+})
+export class PublicationSearchResultListElementComponent implements OnInit {
+    @Input() item: Item;
+
+    @Input() linkType: CollectionElementLinkType;
+
+    @Input() linkTypes = CollectionElementLinkType;
+
+    @Input() context: Context;
+  
+    protected accessCondition: AccessConditionObject;
+    protected itemTitle: string;
+    protected itemPageRoute: string;
+
+    constructor(
+      protected translateService: TranslateService
+    ) {}
+
+    ngOnInit() {
+      this.itemTitle = this.item.firstMetadataValue('dc.title') ?? this.translateService.instant('publication.list.element.title.placeholder');
+      this.itemPageRoute = getItemPageRoute(this.item);
+      if (this.item?.accessStatus) {
+        this.item.accessStatus
+          .pipe(getFirstSucceededRemoteDataWithNotEmptyPayload())
+          .subscribe((access: AccessStatusObject) => {
+            this.accessCondition = Object.assign(new AccessConditionObject(), {id: 0, name: access.status});
+          });
+      }
+    }
+}

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publicaton-search-result-wrapper.component.html/publication-search-result-wrapper.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publicaton-search-result-wrapper.component.html/publication-search-result-wrapper.component.ts
@@ -1,0 +1,43 @@
+
+import { Component, Inject, OnInit, Optional } from "@angular/core";
+import { DSONameService } from "src/app/core/breadcrumbs/dso-name.service";
+import { LinkService } from "src/app/core/cache/builders/link.service";
+import { Context } from "src/app/core/shared/context.model";
+import { ViewMode } from "src/app/core/shared/view-mode.model";
+import { ItemSearchResult } from "src/app/shared/object-collection/shared/item-search-result.model";
+import { listableObjectComponent } from "src/app/shared/object-collection/shared/listable-object/listable-object.decorator";
+import { ItemSearchResultListElementComponent } from "src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component";
+import { TruncatableService } from "src/app/shared/truncatable/truncatable.service";
+import { followLink } from "src/app/shared/utils/follow-link-config.model";
+
+@listableObjectComponent(ItemSearchResult, ViewMode.ListElement, Context.MyDSpaceWorkflow, 'uclouvain')
+@listableObjectComponent(ItemSearchResult, ViewMode.ListElement, Context.MyDSpaceWorkspace, 'uclouvain')
+@listableObjectComponent(ItemSearchResult, ViewMode.ListElement, Context.Search, 'uclouvain')
+@Component({
+    selector: 'ds-publication-search-result-list-element-wrapper',
+    template: `
+        <ds-publication-search-result-list-element 
+            [item]="object?.indexableObject"
+            [linkType]="linkType"
+            [linkTypes]="linkTypes"
+            [context]="context"
+        />
+    `,
+})
+export class PublicationSearchResultWrapperComponent extends ItemSearchResultListElementComponent implements OnInit {
+
+    constructor(
+        protected truncatableService: TruncatableService,
+        public dsoNameService: DSONameService,
+        protected linkService: LinkService,
+    ) {
+        super(truncatableService, dsoNameService);
+    }
+
+    ngOnInit(): void {
+        super.ngOnInit();
+        if (this.dso) {
+            this.linkService.resolveLink(this.dso, followLink('accessStatus'));
+        }
+    }
+}

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/specific-field/author-format-display.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/specific-field/author-format-display.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { Item } from "src/app/core/shared/item.model";
+
+/**
+ * Component to render the author list for a given item using the following rules:
+ * - If there are 5 authors or less, just display all the authors.
+ * - If there are more than 5 authors, display the first 4 and the last one.
+ *  Also add an 'et.al.' at the end of the list to indicate that there are more authors not displayed.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+@Component({
+    selector: 'ds-author-format-display',
+    template: `<div class="d-flex align-items-center">
+        <ng-container *ngFor="let author of authorList; index as i; let last=last;">
+            <ds-item-link-view [metadataValue]="author"/>
+            <span *ngIf="!last" class="mr-2"> ; </span>
+        </ng-container>
+        <span *ngIf="hasEtal"
+              class="ml-1 font-italic text-muted"
+              ngbTooltip="{{ 'search.result.publication.authors.etal.tooltip' | translate }}">et.al.</span>
+    </div>`,
+    styles: ['.orcid-icon { height: 1.1rem; }'],
+})
+export class AuthorFormatDisplayComponent implements OnInit {
+    @Input() item: Item;
+
+    protected authorField = 'dc.contributor.author';
+    protected authorList: any[] = [];
+    protected hasEtal = false;
+    
+    ngOnInit(): void {
+        let authors = this.item.allMetadata(this.authorField);
+        if (authors.length > 5) {
+            let finalAuthor = authors[authors.length - 1];
+            authors = authors.slice(0, 4);
+            authors.push(finalAuthor);
+            this.hasEtal = true;
+        }
+        this.authorList = authors;
+    }
+}

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/type-label-mapping.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/type-label-mapping.ts
@@ -1,0 +1,15 @@
+/**
+ * Mapping to give a label for each publication 'maintype'.
+ * 
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+export const PUBLICATION_TYPES_MAPPING: {[key: string]: string} = {
+    "text::journal-article": "publication.type.journal-article.heading",
+    "text::book": "publication.type.book.heading",
+    "text::book-part": "publication.type.book-part.heading",
+    "text::conference-speech": "publication.type.conference-speech.heading",
+    "text::thesis": "publication.type.dissertation.heading",
+    "text::working-paper": "publication.type.working-paper.heading",
+    "text::report": "publication.type.report.heading",
+    "text::patent": "publication.type.patent.heading",
+}

--- a/src/themes/uclouvain/app/shared/item-link-view/item-link-view.component.ts
+++ b/src/themes/uclouvain/app/shared/item-link-view/item-link-view.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input } from "@angular/core";
+import { MetadataValue } from "src/app/core/shared/metadata.models";
+
+@Component({
+    selector: 'ds-item-link-view',
+    template: `
+        <ng-container [ngTemplateOutlet]="metadataValue?.authority ? displayWithAuthority : defaultDisplay"
+                  [ngTemplateOutletContext]="{metadataValue: metadataValue}"></ng-container>
+        <ng-template #displayWithAuthority let-metadataValue="metadataValue">
+            <a rel="noopener noreferrer" data-test="displayWithAuthority" [routerLink]="['/items/' + metadataValue.authority]">
+                <span>
+                    {{ metadataValue.value }}
+                </span>
+            </a>
+        </ng-template>
+        <ng-template #defaultDisplay let-metadataValue="metadataValue">
+            <span>
+                {{ metadataValue.value }}
+            </span>
+        </ng-template>
+    `
+})
+export class ItemLinkViewComponent {
+    @Input() metadataValue: MetadataValue;
+}

--- a/src/themes/uclouvain/app/shared/object-collection/shared/badges/badges.component.ts
+++ b/src/themes/uclouvain/app/shared/object-collection/shared/badges/badges.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Item } from 'src/app/core/shared/item.model';
+import { getFirstSucceededRemoteDataWithNotEmptyPayload } from 'src/app/core/shared/operators';
+import { AccessConditionObject } from 'src/app/core/submission/models/access-condition.model';
+import { AccessStatusObject } from 'src/app/shared/object-collection/shared/badges/access-status-badge/access-status.model';
+import { BadgesComponent as BaseComponent } from 'src/app/shared/object-collection/shared/badges/badges.component';
+
+@Component({
+    selector: 'ds-badges',
+    styleUrls: ['../../../../../../../app/shared/object-collection/shared/badges/badges.component.scss'],
+    template: `<div class="d-flex flex-row align-items-center gapx-1">
+        <div class="d-flex flex-grow-1 gapx-2">
+            <ds-custom-type-badge [object]="object" [displayEntityType]="displayType" />
+            <ng-container *ngIf="isMyDSpaceStatus">
+                <ds-themed-my-dspace-status-badge [context]="context"></ds-themed-my-dspace-status-badge>
+            </ng-container>
+        </div> 
+        <ng-container *ngIf="showAccessStatus && accessCondition && accessCondition.name !== 'unknown'">
+            <ds-access-conditions [accessConditions]="[accessCondition]"></ds-access-conditions>
+        </ng-container>
+    </div>`,
+})
+export class BadgesComponent extends BaseComponent implements OnInit {
+    protected accessCondition: AccessConditionObject;
+
+    ngOnInit() {
+        if (this.showAccessStatus && this.object instanceof Item) {
+            let item = this.object as Item;
+            if (item.accessStatus) {
+                item.accessStatus.pipe(
+                    getFirstSucceededRemoteDataWithNotEmptyPayload()
+                ).subscribe((access: AccessStatusObject) =>
+                    this.accessCondition = Object.assign(new AccessConditionObject(), {id: 0, name: access.status})
+                );
+            }
+        }
+    }
+}

--- a/src/themes/uclouvain/app/shared/object-collection/shared/badges/my-dspace-status-badge/my-dspace-status-badge.component.scss
+++ b/src/themes/uclouvain/app/shared/object-collection/shared/badges/my-dspace-status-badge/my-dspace-status-badge.component.scss
@@ -1,0 +1,26 @@
+.badge {
+    font-size: 0.8rem;
+    line-height: 1.5;
+    background: none;
+    box-shadow: rgba(0, 0, 0, 0.01) 0px 2px 5px 0px, rgba(0, 0, 0, 0.1) 0px 0px 0px 1px;
+}
+
+.badge-validation {
+    color: var(--bs-warning);
+}
+
+.badge-waiting-controller {
+    color: var(--bs-info);
+}
+
+.badge-workspace {
+    color: var(--bs-primary);
+}
+
+.badge-archived {
+    color: darken($green, 10);
+}
+
+.badge-workflow {
+    color: var(--bs-info);
+}

--- a/src/themes/uclouvain/app/shared/object-collection/shared/badges/my-dspace-status-badge/my-dspace-status-badge.component.ts
+++ b/src/themes/uclouvain/app/shared/object-collection/shared/badges/my-dspace-status-badge/my-dspace-status-badge.component.ts
@@ -1,0 +1,48 @@
+import { Component, OnInit } from "@angular/core";
+import { Context } from "src/app/core/shared/context.model";
+import { MyDSpaceStatusBadgeComponent as BaseComponent } from "src/app/shared/object-collection/shared/badges/my-dspace-status-badge/my-dspace-status-badge.component";
+
+
+@Component({
+    selector: 'ds-my-dspace-status-badge',
+    styleUrls: ['./my-dspace-status-badge.component.scss'],
+    template: `
+        <div>
+            <span [className]="badgeClass" class="py-1 px-2">
+                <i *ngIf="badgeLogo" [className]="badgeLogo"></i>
+                {{('mydspace.status.' + badgeContent) | translate}}
+            </span>
+        </div>
+    `,
+  })
+  export class MyDSpaceStatusBadgeComponent extends BaseComponent implements OnInit {
+    protected badgeLogo: string;
+    
+    ngOnInit() {
+        this.badgeContent = this.context;
+        this.badgeClass = 'badge py-1 px-2 ';
+        switch (this.context) {
+          case Context.MyDSpaceValidation:
+            this.badgeClass += 'badge-validation';
+            this.badgeLogo = 'fa-solid fa-list-check';
+            break;
+          case Context.MyDSpaceWaitingController:
+            this.badgeClass += 'badge-waiting-controller';
+            this.badgeLogo = 'fa-solid fa-clock';
+            break;
+          case Context.MyDSpaceWorkspace:
+            this.badgeClass += 'badge-workspace';
+            this.badgeLogo = 'fa-solid fa-pen';
+            break;
+          case Context.MyDSpaceArchived:
+            this.badgeClass += 'badge-archived';
+            this.badgeLogo = 'fa-solid fa-box-archive';
+            break;
+          case Context.MyDSpaceWorkflow:
+            this.badgeClass += 'badge-workflow';
+            this.badgeLogo = 'fa-solid fa-clock';
+            break;
+        }
+      }
+  }
+  

--- a/src/themes/uclouvain/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
+++ b/src/themes/uclouvain/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component.ts
@@ -1,0 +1,14 @@
+
+import { Component } from "@angular/core";
+import { ItemListPreviewComponent as BaseComponent } from "src/app/shared/object-list/my-dspace-result-list-element/item-list-preview/item-list-preview.component";
+
+@Component({
+    selector: 'ds-item-list-preview',
+    template: `
+        <ds-publication-search-result-list-element 
+            [item]="item"
+            [context]="badgeContext"
+        />
+    `,
+})
+export class ItemListPreviewComponent extends BaseComponent {}

--- a/src/themes/uclouvain/app/shared/object-list/object-list.component.html
+++ b/src/themes/uclouvain/app/shared/object-list/object-list.component.html
@@ -1,0 +1,52 @@
+<ds-pagination
+        [paginationOptions]="config"
+        [pageInfoState]="objects?.payload"
+        [collectionSize]="objects?.payload?.totalElements"
+        [objects]="objects"
+        [sortOptions]="sortConfig"
+        [hideGear]="hideGear"
+        [hidePagerWhenSinglePage]="hidePagerWhenSinglePage"
+        [hidePaginationDetail]="hidePaginationDetail"
+        [showPaginator]="showPaginator"
+        (pageChange)="onPageChange($event)"
+        (pageSizeChange)="onPageSizeChange($event)"
+        (sortDirectionChange)="onSortDirectionChange($event)"
+        (sortFieldChange)="onSortFieldChange($event)"
+        (paginationChange)="onPaginationChange($event)"
+        (prev)="goPrev()"
+        (next)="goNext()">
+
+    <ul *ngIf="objects?.hasSucceeded" class="list-unstyled publication-list" [ngClass]="{'ml-4': selectable}">
+        <li *ngFor="let object of objects?.payload?.page; let i = index; let last = last" class="p-3 d-flex mt-4"
+            [attr.data-test]="'list-object' | dsBrowserOnly">
+            <ds-selectable-list-item-control *ngIf="selectable" [index]="i"
+                                             [object]="object"
+                                             [selectionConfig]="selectionConfig"
+                                             (deselectObject)="deselectObject.emit($event)"
+                                             (selectObject)="selectObject.emit($event)"></ds-selectable-list-item-control>
+
+            <div class="d-flex flex-column align-items-center">
+                <ds-importable-list-item-control *ngIf="importable" [object]="object"
+                                                 [importConfig]="importConfig"
+                                                 (importObject)="importObject.emit($event)"></ds-importable-list-item-control>
+
+                <div *ngIf="object?.matchObjects?.length > 0" class="pt-1">
+                    <i class="fa-solid fa-file-circle-exclamation fa-lg text-warning"></i>
+                </div>
+            </div>
+
+            <ds-listable-object-component-loader [object]="object"
+                                                 [viewMode]="viewMode"
+                                                 [index]="i"
+                                                 [context]="context"
+                                                 [linkType]="linkType"
+                                                 [listID]="selectionConfig?.listId"
+                                                 [customData]="customData"
+                                                 [showMetrics]="showMetrics"
+                                                 [showThumbnails]="showThumbnails"
+                                                 (contentChange)="contentChange.emit()"
+                                                 (customEvent)="customEvent.emit($event)"
+                                                 (contentChange)="contentChange.emit($event)"></ds-listable-object-component-loader>
+        </li>
+    </ul>
+</ds-pagination>

--- a/src/themes/uclouvain/app/shared/object-list/object-list.component.ts
+++ b/src/themes/uclouvain/app/shared/object-list/object-list.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { ObjectListComponent as BaseComponent} from '../../../../../app/shared/object-list/object-list.component';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../app/my-dspace-page/my-dspace-page.component';
+import { SearchConfigurationService } from '../../../../../app/core/shared/search/search-configuration.service';
+
+/** A component to display a list of objects and widget to navigate through them */
+@Component({
+  selector: 'ds-object-list',
+  styleUrls: ['../../../../../app/shared/object-list/object-list.component.scss'],
+  styles: ['li { box-shadow: rgba(0, 0, 0, 0.08) 0px 0px 0px 1px; border-radius: 2px; transition: 0.2s ease; }'],
+  templateUrl: './object-list.component.html',
+  providers: [
+    {
+      provide: SEARCH_CONFIG_SERVICE,
+      useClass: SearchConfigurationService
+    }
+  ]
+})
+export class ObjectListComponent extends BaseComponent {}

--- a/src/themes/uclouvain/app/shared/search/search-results/search-results.component.html
+++ b/src/themes/uclouvain/app/shared/search/search-results/search-results.component.html
@@ -1,0 +1,57 @@
+<!-- DISABLED :: move into the 'ds-search' component from UCLouvain theme
+<div class="d-flex justify-content-between">
+    <ds-search-export-csv *ngIf="showCsvExport" [searchConfig]="searchConfig"></ds-search-export-csv>
+</div>
+-->
+<div *ngIf="searchResults && searchResults?.hasSucceeded && !searchResults?.isLoading && searchResults?.payload?.page.length > 0" @fadeIn>
+    <ds-alert *ngIf="showSearchResultNotice" [type]="searchResultNoticeType" [content]="searchResultNotice"></ds-alert>
+
+    <!-- SORT RESULT ====================================================== -->
+    <div class="input-group my-2">
+        <div class="input-group-prepend">
+            <div class="input-group-text">
+                <i class="fa fa-sort-amount-{{ searchConfig.sort.direction === SortDirection.ASC ? 'up' : 'down' }}"></i>
+            </div>
+        </div>
+        <select *ngIf="(sortOptionsList$ | async) as sortOptionsList"
+                [id]="'search-sort'"
+                class="form-control"
+                [ngbTooltip]="'search.sidebar.settings.sort-by' | translate"
+                (change)="reloadOrder($event)">
+            <option *ngFor="let sortOption of sortOptionsList"
+                    [value]="sortOption.field + ',' + sortOption.direction.toString()"
+                    [selected]="isOptionSelected(sortOption) ? 'selected': null">
+                {{'sorting.' + sortOption.field + '.' + sortOption.direction | translate}}
+            </option>
+        </select>
+    </div>
+    <!-- SEARCH RESULTS =================================================== -->
+    <ds-viewable-collection
+            [config]="searchConfig.pagination"
+            [sortConfig]="searchConfig.sort"
+            [objects]="searchResults"
+            [hideGear]="true"
+            [selectable]="selectable"
+            [selectionConfig]="selectionConfig"
+            [linkType]="linkType"
+            [context]="context"
+            [hidePaginationDetail]="hidePaginationDetail"
+            [showThumbnails]="showThumbnails"
+            [customData]="customData"
+            (contentChange)="contentChange.emit($event)"
+            (customEvent)="emitCustomEvent($event)"
+            (deselectObject)="deselectObject.emit($event)"
+            (selectObject)="selectObject.emit($event)">
+    </ds-viewable-collection>
+</div>
+<ds-themed-loading *ngIf="isLoading()" message="{{'loading.search-results' | translate}}"></ds-themed-loading>
+<ds-error *ngIf="showError()"
+          message="{{errorMessageLabel() | translate}}"></ds-error>
+<div *ngIf="searchResults?.payload?.page.length == 0 || searchResults?.statusCode == 400">
+    {{ 'search.results.no-results' | translate }}
+    <a [routerLink]="['/search']"
+       [queryParams]="{ query: surroundStringWithQuotes(searchConfig?.query) }"
+       queryParamsHandling="merge">
+        {{"search.results.no-results-link" | translate}}
+    </a>
+</div>

--- a/src/themes/uclouvain/app/shared/search/search-results/search-results.component.ts
+++ b/src/themes/uclouvain/app/shared/search/search-results/search-results.component.ts
@@ -1,0 +1,87 @@
+import { SearchResultsComponent as BaseComponent } from '../../../../../../app/shared/search/search-results/search-results.component';
+import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
+import { fadeIn, fadeInOut } from '../../../../../../app/shared/animations/fade';
+import { BehaviorSubject, Observable, Subscription } from 'rxjs';
+import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
+import { SortDirection, SortOptions } from '../../../../../../app/core/cache/models/sort-options.model';
+import { SEARCH_CONFIG_SERVICE } from '../../../../../../app/my-dspace-page/my-dspace-page.component';
+import { SearchConfigurationService } from '../../../../../../app/core/shared/search/search-configuration.service';
+import { SearchConfig } from '../../../../../../app/core/shared/search/search-filters/search-config.model';
+import { PaginationService } from '../../../../../../app/core/pagination/pagination.service';
+
+@Component({
+    selector: 'ds-search-results',
+    templateUrl: './search-results.component.html',
+    animations: [fadeIn, fadeInOut],
+    providers: [
+      {
+        provide: SEARCH_CONFIG_SERVICE,
+        useClass: SearchConfigurationService
+      }
+    ]
+  })
+  export class SearchResultsComponent extends BaseComponent implements OnInit, OnDestroy {
+  
+    // COMPONENT ATTRIBUTES =====================================================
+    sortOptionsList$: BehaviorSubject<SortOptions[]> = new BehaviorSubject<SortOptions[]>([]);
+    private subs: Subscription[] = [];
+    protected readonly SortDirection = SortDirection;
+    protected activeSortOption: SortOptions = null;
+  
+    // CONSTRUCTOR & HOOKS ======================================================
+    constructor(
+      protected paginationService: PaginationService,
+      @Inject(SEARCH_CONFIG_SERVICE) public searchConfigService: SearchConfigurationService,
+    ){ super(); }
+  
+    /** OnInit hook */
+    ngOnInit() {
+      this.paginationService.getCurrentSort(this.searchConfigService.paginationID, null, true).subscribe((currentSortOption: SortOptions) => {
+        if (currentSortOption != null) {
+          this.activeSortOption = new SortOptions(currentSortOption.field, currentSortOption.direction);
+        }
+      });
+      const configuration$: Observable<string> = this.searchConfigService
+        .getCurrentConfiguration('')
+        .pipe(distinctUntilChanged());
+      const searchSortOptions$: Observable<SortOptions[]> = configuration$
+        .pipe(
+          switchMap((configuration: string) => this.searchConfigService.getConfigurationSearchConfig(configuration)),
+          map((searchConfig: SearchConfig) => this.searchConfigService.getConfigurationSortOptions(searchConfig)),
+          distinctUntilChanged()
+        );
+      this.subs.push(
+        searchSortOptions$.subscribe((options: SortOptions[]) => this.sortOptionsList$.next(options))
+      );
+    }
+  
+    /** OnDestroy hook */
+    ngOnDestroy() {
+      this.subs.forEach(s => s.unsubscribe());
+    }
+  
+    // COMPONENT FUNCTIONS ======================================================
+    /**
+     * Handler to manage sort result changes.
+     * @param event The triggered event.
+     */
+    reloadOrder(event: Event): void {
+      const values = (event.target as HTMLInputElement).value.split(',');
+      this.activeSortOption = new SortOptions(values[0], values[1] as SortDirection);
+      this.paginationService.updateRoute(this.searchConfigService.paginationID, {
+        sortField: this.activeSortOption.field,
+        sortDirection: this.activeSortOption.direction,
+        page: 1
+      });
+    }
+  
+    /**
+     * Check if the given sort option is selected. This is done by checking the activeSortOption property.
+     * @param option The sort option to check.
+     */
+    isOptionSelected(option: SortOptions): boolean {
+      return (this.activeSortOption != null) 
+        ? (option.field === this.activeSortOption.field && option.direction === this.activeSortOption.direction)
+        : (option.field === this.sortConfig?.field && option.direction === this.sortConfig?.direction);
+    }
+  }

--- a/src/themes/uclouvain/eager-theme.module.ts
+++ b/src/themes/uclouvain/eager-theme.module.ts
@@ -14,6 +14,7 @@ import { HeaderNavbarWrapperComponent } from './app/header-nav-wrapper/header-na
 import { HomeNewsComponent } from './app/home-page/home-news/home-news.component';
 import { NavbarComponent } from './app/navbar/navbar.component';
 import { OrgUnitInlineLabeledGroupContentComponent } from './app/shared/form/builder/models/org-unit/org-unit-inline-labeled-group-content.component';
+import { PublicationModule } from './app/entity-groups/publication-entity/publication.module';
 
 /**
  * Add components that use a custom decorator to ENTRY_COMPONENTS as well as DECLARATIONS.
@@ -42,6 +43,7 @@ const DECLARATIONS = [
     NavbarModule,
     ExploreModule,
     FooterModule,
+    PublicationModule,
   ],
   declarations: DECLARATIONS,
   providers: [

--- a/src/themes/uclouvain/lazy-theme.module.ts
+++ b/src/themes/uclouvain/lazy-theme.module.ts
@@ -68,6 +68,10 @@ import { SubmissionSectionUploadFileComponent } from './app/submission/sections/
 import { SharedThemeModule } from './shared-theme.module';
 import { CreativeCommonsLicenseComponent } from './app/shared/cc-license/creative-commons-licence.component';
 import { FileDownloadLinkComponent } from './app/shared/file-download-link/file-download-link.component';
+import { SearchResultsComponent } from './app/shared/search/search-results/search-results.component';
+import { ObjectListComponent } from './app/shared/object-list/object-list.component';
+import { BadgesComponent } from './app/shared/object-collection/shared/badges/badges.component';
+import { MyDSpaceStatusBadgeComponent } from './app/shared/object-collection/shared/badges/my-dspace-status-badge/my-dspace-status-badge.component';
 
 const DECLARATIONS = [
   AdminSidebarComponent,
@@ -81,7 +85,11 @@ const DECLARATIONS = [
   SearchSidebarComponent,
   SubmissionSectionUploadFileComponent,
   CreativeCommonsLicenseComponent,
-  FileDownloadLinkComponent
+  FileDownloadLinkComponent,
+  SearchResultsComponent,
+  ObjectListComponent,
+  BadgesComponent,
+  MyDSpaceStatusBadgeComponent,
 ];
 
 @NgModule({

--- a/src/themes/uclouvain/shared-theme.module.ts
+++ b/src/themes/uclouvain/shared-theme.module.ts
@@ -2,6 +2,8 @@ import { NgModule } from '@angular/core';
 import { AccessConditionsComponent } from './app/shared/access-conditions/access-conditions.component';
 import { CommonModule } from '@angular/common';
 import { SharedModule } from '../../app/shared/shared.module';
+import { CustomTypeBadgeComponent } from './app/entity-groups/publication-entity/search-result-list-elements/custom-type-badge/custom-type-badge.component';
+import { ItemLinkViewComponent } from './app/shared/item-link-view/item-link-view.component';
 
 @NgModule({
   imports: [
@@ -10,9 +12,13 @@ import { SharedModule } from '../../app/shared/shared.module';
   ],
   declarations: [
     AccessConditionsComponent,
+    CustomTypeBadgeComponent,
+    ItemLinkViewComponent,
   ],
   exports: [
     AccessConditionsComponent,
+    CustomTypeBadgeComponent,
+    ItemLinkViewComponent,
   ]
 })
 export class SharedThemeModule { }

--- a/src/themes/uclouvain/styles/_theme_css_variable_overrides.scss
+++ b/src/themes/uclouvain/styles/_theme_css_variable_overrides.scss
@@ -25,7 +25,7 @@
   --ds-navbar-link-color: #{$dark};
   --ds-navbar-link-color-hover: #{$burgundy};
 
-  --ds-breadcrumb-bg: #{$gray-150};
+  --ds-breadcrumb-bg: #{$gray-100};
   --ds-breadcrumb-link-color: #{$burgundy};
 
   // Bootstrap variables


### PR DESCRIPTION
Each search results now displays in a component containing:

- The type of the item, if 'publication' then we also display the type of publication.
- The access-type of the item,
- The title of the item,
- The list of authors,
- A section for the citation that will be implemented in the future.

Also fixed: redirect to item page instead of metadata view for workflow and workspace items.