### PR TITLE
[ADD] feat(notification): Allow survey notification when deposit

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -44,6 +44,7 @@ import { PaginationComponentOptions } from '../shared/pagination/pagination-comp
 import { SearchConfig } from '../shared/search/search-filters/search-config.model';
 import { SidebarService } from '../shared/sidebar/sidebar.service';
 import { Subscription } from '../shared/subscriptions/models/subscription.model';
+import { SurveysService } from '../shared/surveys/surveys.service';
 import { CoarNotifyConfigDataService } from '../submission/sections/section-coar-notify/coar-notify-config-data.service';
 import { SubmissionCoarNotifyConfig } from '../submission/sections/section-coar-notify/submission-coar-notify.config';
 import { AuditDataService } from './audit/audit-data.service';
@@ -316,7 +317,7 @@ const PROVIDERS = [
   SubmissionJsonPatchOperationsService,
   JsonPatchOperationsBuilder,
   UUIDService,
-  NotificationsService,
+  SurveysService,
   WorkspaceitemDataService,
   WorkflowItemDataService,
   DSpaceObjectDataService,

--- a/src/app/shared/surveys/surveys.service.ts
+++ b/src/app/shared/surveys/surveys.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { hasValue } from '../empty.util';
+
+@Injectable()
+export class SurveysService {
+
+  getCollectionSurvey(collectionId: string): string|undefined {
+    let surveys: {[key: string]: string} = hasValue(environment.submission)
+      ? environment.submission['collectionSurveys']
+      : {};
+    surveys = surveys || {};  // To ensure than objects UUID array isn't undefined
+    return Object.entries(surveys).find(([_, value]) => value === collectionId)?.[0];
+  }
+
+}

--- a/src/app/submission/objects/submission-objects.actions.ts
+++ b/src/app/submission/objects/submission-objects.actions.ts
@@ -773,16 +773,17 @@ export class DepositSubmissionSuccessAction implements Action {
   type = SubmissionObjectActionTypes.DEPOSIT_SUBMISSION_SUCCESS;
   payload: {
     submissionId: string;
+    collectionId: string;
   };
 
   /**
    * Create a new DepositSubmissionSuccessAction
    *
-   * @param submissionId
-   *    the submission's ID to deposit
+   * @param submissionId the submission's ID to deposit
+   * @param collectionId the collection's ID where the submission was submitted
    */
-  constructor(submissionId: string) {
-    this.payload = { submissionId };
+  constructor(submissionId: string, collectionId: string) {
+    this.payload = { submissionId, collectionId };
   }
 }
 

--- a/src/app/submission/objects/submission-objects.effects.ts
+++ b/src/app/submission/objects/submission-objects.effects.ts
@@ -52,6 +52,7 @@ import {
 import { FormState } from '../../shared/form/form.reducer';
 import { NotificationOptions } from '../../shared/notifications/models/notification-options.model';
 import { NotificationsService } from '../../shared/notifications/notifications.service';
+import { SurveysService } from '../../shared/surveys/surveys.service';
 import { followLink } from '../../shared/utils/follow-link-config.model';
 import { SectionsService } from '../sections/sections.service';
 import { SectionsType } from '../sections/sections-type';
@@ -352,7 +353,10 @@ export class SubmissionObjectEffects {
     withLatestFrom(this.store$),
     switchMap(([action, state]: [DepositSubmissionAction, any]) => {
       return this.submissionService.depositSubmission(state.submission.objects[action.payload.submissionId].selfUrl).pipe(
-        map(() => new DepositSubmissionSuccessAction(action.payload.submissionId)),
+        map(() => new DepositSubmissionSuccessAction(
+          action.payload.submissionId,
+          state.submission.objects[action.payload.submissionId].collection
+        )),
         catchError((error: unknown) => observableOf(new DepositSubmissionErrorAction(action.payload.submissionId))));
     })));
 
@@ -376,6 +380,12 @@ export class SubmissionObjectEffects {
    */
   depositSubmissionSuccess$ = createEffect(() => this.actions$.pipe(
     ofType(SubmissionObjectActionTypes.DEPOSIT_SUBMISSION_SUCCESS),
+    tap((action: DepositSubmissionSuccessAction) => {
+      const surveyId = this.surveysService.getCollectionSurvey(action.payload.collectionId);
+      if (isNotEmpty(surveyId)) {
+        this.notificationsService.info(null, this.translate.instant('submission.sections.general.survey.' + surveyId + '.content'), { timeOut: 0 }, true);
+      }
+    }),
     tap(() => this.notificationsService.success(null, this.translate.get('submission.sections.general.deposit_success_notice'))),
     tap(() => this.submissionService.redirectToMyDSpace())), { dispatch: false });
 
@@ -452,7 +462,9 @@ export class SubmissionObjectEffects {
     private store$: Store<any>,
     private submissionService: SubmissionService,
     private submissionObjectService: SubmissionObjectDataService,
-    private translate: TranslateService) {
+    private translate: TranslateService,
+    private surveysService: SurveysService
+  ) {
   }
 
   /**

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3852,6 +3852,7 @@
   "submission.sections.general.save_success_notice": "Submission saved successfully.",
   "submission.sections.general.search-collection": "Search for a collection",
   "submission.sections.general.sections_not_valid": "There are incomplete sections.",
+  "submission.sections.general.survey.limeSurvey1.content": "Your dissertation for science : <a href=\"https://limesurvey.uclouvain.be/limesurvey319/index.php/498887?lang=en\" target=\"_blank\">click here</a>!<br/>Thank you in advance for your help!",
   "submission.sections.identifiers.info": "The following identifiers will be created for your item:",
   "submission.sections.identifiers.no_handle": "No handles have been minted for this item.",
   "submission.sections.identifiers.no_doi": "No DOIs have been minted for this item.",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -11146,6 +11146,8 @@
   // "submission.sections.general.sections_not_valid": "There are incomplete sections.",
   "submission.sections.general.sections_not_valid": "Sections incomplètes.",
 
+  "submission.sections.general.survey.limeSurvey1.content": "Votre mémoire pour la science : <a href=\"https://limesurvey.uclouvain.be/limesurvey319/index.php/498887?lang=fr\" target=\"_blank\">cliquez ici</a> !<br/>Merci d’avance pour votre aide !",
+
   // "submission.sections.identifiers.info": "The following identifiers will be created for your item:",
   // TODO New key - Add a translation
   "submission.sections.identifiers.info": "The following identifiers will be created for your item:",

--- a/src/config/submission-config.interface.ts
+++ b/src/config/submission-config.interface.ts
@@ -70,4 +70,5 @@ export interface SubmissionConfig extends Config {
   dynamicFields: DynamicFieldsConfig[];
   enableShortcutPanelFor?: string[];  // must contain the collection UUID for which the shortcut panel should be enabled
   disclaimerSectionFor?: string[]; // Provide collection to display a disclaimer when submitting a new item.
+  collectionSurveys?: { [key: string]: string } ;
 }


### PR DESCRIPTION
* Closes bibsys/DSpace#177.
* When submitting object into configured collection, a notification toastr could be displayed inclucing link to a survey.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
