### PR TITLE
[UPD] feat(item-page): Component to display abstracts of an item.

### DIFF
--- a/src/themes/uclouvain/app/entity-groups/publication-entity/item-pages/publication-page.component.html
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/item-pages/publication-page.component.html
@@ -52,8 +52,7 @@
             <ng-container *ngIf="object.hasMetadata('dc.description.abstract')">
               <dt>{{ "item.page.abstract" | translate }}</dt>
               <dd>
-                <ds-generic-item-page-field [item]="object" [fields]="['dc.description.abstract']">
-                </ds-generic-item-page-field>
+                <ds-item-page-abstract-custom-field [item]="object"/>
               </dd>
             </ng-container>
             <ng-container *ngIf="object.hasMetadata('dc.date.issued')">

--- a/src/themes/uclouvain/app/entity-groups/publication-entity/item-pages/publication-page.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/publication-entity/item-pages/publication-page.component.ts
@@ -18,6 +18,7 @@ import { AsyncPipe, NgComponentOutlet, NgFor, NgIf, NgTemplateOutlet } from '@an
 import { TranslateModule } from '@ngx-translate/core';
 import { ContextMenuComponent } from 'src/app/shared/context-menu/context-menu.component';
 import { ItemPageMetadataListComponent } from '../../../item-page/simple/field-components/specific-field/metadata-list/item-page-metadata-list.component';
+import { ItemPageAbstractCustomFieldComponent } from '../../../item-page/simple/field-components/specific-field/abstract/item-page-abstract-field.component';
 
 @listableObjectComponent('Publication', ViewMode.StandalonePage, Context.Any, 'uclouvain')
 @Component({
@@ -42,6 +43,7 @@ import { ItemPageMetadataListComponent } from '../../../item-page/simple/field-c
 		NgFor,
 		NgTemplateOutlet,
 		ItemPageMetadataListComponent,
+		ItemPageAbstractCustomFieldComponent,
 	],
 })
 export class PublicationPageComponent extends ItemComponent implements OnInit {

--- a/src/themes/uclouvain/app/item-page/simple/field-components/specific-field/abstract/item-page-abstract-field.component.ts
+++ b/src/themes/uclouvain/app/item-page/simple/field-components/specific-field/abstract/item-page-abstract-field.component.ts
@@ -1,0 +1,89 @@
+import { NgIf } from "@angular/common";
+import { Component, Input, OnInit } from "@angular/core";
+import { BrowseDefinitionDataService } from "src/app/core/browse/browse-definition-data.service";
+import { BrowseService } from "src/app/core/browse/browse.service";
+import { LocaleService } from "src/app/core/locale/locale.service";
+import { Item } from "src/app/core/shared/item.model";
+import { MetadataValue } from "src/app/core/shared/metadata.models";
+import { ItemPageAbstractFieldComponent as BaseComponent } from "src/app/item-page/simple/field-components/specific-field/abstract/item-page-abstract-field.component";
+import { TruncatablePartComponent } from "src/app/shared/truncatable/truncatable-part/truncatable-part.component";
+import { TruncatableComponent } from "src/app/shared/truncatable/truncatable.component";
+
+/**
+ * Custom component to display different abstract and their language.
+ * Each abstract is 'truncatable' if is longer than 3 lines.
+ *
+ * @author Michaël Pourbaix (michael.pourbaix@uclouvain.be)
+ */
+@Component({
+  selector: 'ds-item-page-abstract-custom-field',
+  template: `
+    <div>
+      <ds-truncatable *ngIf="abstractToDisplay" [id]="getTruncateId()">
+        <ds-truncatable-part [id]="getTruncateId()" [minLines]="minLines">
+          <span *ngIf="abstractToDisplay.language" class="px-1 text-nowrap font-italic text-muted">
+            ({{ abstractToDisplay.language }})
+          </span>
+          <span>{{ abstractToDisplay.value }}</span>
+        </ds-truncatable-part>
+      </ds-truncatable>
+    </div> 
+    `,
+  standalone: true,
+  imports: [
+    TruncatableComponent,
+    TruncatablePartComponent,
+    NgIf,
+  ]
+})
+export class ItemPageAbstractCustomFieldComponent extends BaseComponent implements OnInit {
+
+  /** The item to extract the abstracts for. */
+  @Input() item: Item;
+  /** The minimum number of lines to display for an abstract. */
+  @Input() minLines: number = 10;
+
+  protected abstractToDisplay: MetadataValue;
+
+  constructor(
+    protected browseDefinitionDataService: BrowseDefinitionDataService,
+    protected browseService: BrowseService,
+    protected localeService: LocaleService,
+  ) {
+    super(browseDefinitionDataService, browseService)
+  }
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    this.abstractToDisplay = this.getBestAbstract(
+      this.item.allMetadata('dc.description.abstract'),
+      this.localeService.getCurrentLanguageCode()
+    );
+  }
+
+  /**
+   * Get the best possible abstract using the current user language.
+   * @param abstracts All the abstracts from the item.
+   * @param currentUserLanguage The current language selected by the user in the UI.
+   * @returns The best possible match or null if there are no abstracts.
+   */
+  protected getBestAbstract(abstracts: MetadataValue[], currentUserLanguage: string): MetadataValue {
+    // If we have only one abstract, select it.
+    if (abstracts.length < 2) {
+      return abstracts[0] || null;
+    }
+    // If we have more than one abstract, we need to find the best match using the following rules:
+    //    - If there is an abstract for the selected language, use it.
+    //    - If there is no abstract for the selected language, use the one in 'en'.
+    //    - If there is no abstract for the selected language and none in 'en', use the first abstract.
+    let matchingAbstract: MetadataValue;
+    if (!(matchingAbstract = abstracts.find(mv => mv.language == currentUserLanguage))) {
+      matchingAbstract = abstracts.find(mv => mv.language == 'en') || abstracts[0];
+    }
+    return matchingAbstract;
+  }
+
+  protected getTruncateId(): string {
+    return this.item.id + '-dc.description.abstract';
+  }
+}


### PR DESCRIPTION
Added a custom component in the item page that displays all the available abstracts and their language. If an abstract is too long (more than 3 lines by default) it is truncated.

#### PLEASE REVIEW #105 BEFORE THIS ONE