### PR TITLE
[ADD] feat(workflow): Allow admin to unassign claimed task

### DIFF
--- a/src/app/admin/admin-workflow-page/admin-workflow-search-results/actions/workflow-item/workflow-item-admin-workflow-actions.component.html
+++ b/src/app/admin/admin-workflow-page/admin-workflow-search-results/actions/workflow-item/workflow-item-admin-workflow-actions.component.html
@@ -5,4 +5,13 @@
   <a [ngClass]="{'btn-sm': small}" class="btn btn-light my-1 send-back-link" [routerLink]="[getSendBackRoute()]" [title]="'admin.workflow.item.send-back' | translate">
     <i class="fa fa-hand-point-left"></i><span *ngIf="!small" class="d-none d-sm-inline"> {{"admin.workflow.item.send-back" | translate}}</span>
   </a>
+
+  <a *ngFor="let task of claimedTaskList"
+     [ngClass]="{'btn-sm': small}"
+     class="btn btn-secondary my-1 unassign-link"
+     [title]="'submission.workflow.tasks.claimed.return' | translate"
+     (click)="returnToPoolTask(task)"
+  >
+    <i class="fa fa-undo"></i><span *ngIf="!small" class="d-none d-sm-inline"> {{ "admin.workflow.item.unassign" | translate }}</span>
+  </a>
 </div>

--- a/src/app/admin/admin-workflow-page/admin-workflow-search-results/actions/workflow-item/workflow-item-admin-workflow-actions.component.ts
+++ b/src/app/admin/admin-workflow-page/admin-workflow-search-results/actions/workflow-item/workflow-item-admin-workflow-actions.component.ts
@@ -1,15 +1,15 @@
-import {
-  NgClass,
-  NgIf,
-} from '@angular/common';
-import {
-  Component,
-  Input,
-} from '@angular/core';
+import { NgClass, NgForOf, NgIf, } from '@angular/common';
+import { ChangeDetectorRef, Component, Input, } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { tap } from 'rxjs/operators';
 
 import { WorkflowItem } from '../../../../../core/submission/models/workflowitem.model';
+import { ClaimedTaskDataService } from '../../../../../core/tasks/claimed-task-data.service';
+import { ClaimedTask } from '../../../../../core/tasks/models/claimed-task-object.model';
+import { ProcessTaskResponse } from '../../../../../core/tasks/models/process-task-response';
+import { NotificationOptions } from '../../../../../shared/notifications/models/notification-options.model';
+import { NotificationsService } from '../../../../../shared/notifications/notifications.service';
 import {
   getWorkflowItemDeleteRoute,
   getWorkflowItemSendBackRoute,
@@ -20,7 +20,7 @@ import {
   styleUrls: ['./workflow-item-admin-workflow-actions.component.scss'],
   templateUrl: './workflow-item-admin-workflow-actions.component.html',
   standalone: true,
-  imports: [NgClass, RouterLink, NgIf, TranslateModule],
+  imports: [NgClass, RouterLink, NgIf, TranslateModule, NgForOf],
 })
 /**
  * The component for displaying the actions for a list element for a workflow-item on the admin workflow search page
@@ -37,6 +37,16 @@ export class WorkflowItemAdminWorkflowActionsComponent {
    */
   @Input() public small: boolean;
 
+  @Input() public claimedTaskList: ClaimedTask[];
+
+  constructor(
+    private claimedTaskDataService: ClaimedTaskDataService,
+    private notificationsService: NotificationsService,
+    private translateService: TranslateService,
+    private cdr: ChangeDetectorRef
+  ) { }
+
+
   /**
    * Returns the path to the delete page of this workflow item
    */
@@ -49,6 +59,33 @@ export class WorkflowItemAdminWorkflowActionsComponent {
    */
   getSendBackRoute(): string {
     return getWorkflowItemSendBackRoute(this.wfi.id);
+  }
+
+  /** Unassign a claimed task. */
+  returnToPoolTask(task: ClaimedTask): void {
+    this.claimedTaskDataService
+      .returnToPoolTask(task.id)
+      .pipe(tap((response: ProcessTaskResponse) => this.handleResponse(response)))
+      .subscribe((response: ProcessTaskResponse) => {
+        if (response.hasSucceeded) {
+          // remove the corresponding claim task from the list
+          this.claimedTaskList = this.claimedTaskList.filter(t => t.id !== task.id);
+          this.cdr.detectChanges();
+        }
+      });
+  }
+
+  private handleResponse(response: ProcessTaskResponse) {
+    if (response.hasSucceeded) {
+      this.notificationsService.success(null,
+        this.translateService.get('admin.workflow.item.unassign.success'),
+        new NotificationOptions(5000, false),
+      );
+    } else {
+      this.notificationsService.error(null,
+        this.translateService.get('admin.workflow.item.unassign.error'),
+        new NotificationOptions(20000, true));
+    }
   }
 
 }

--- a/src/app/admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-list-element/workflow-item/workflow-item-search-result-admin-workflow-list-element.component.html
+++ b/src/app/admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-list-element/workflow-item/workflow-item-search-result-admin-workflow-list-element.component.html
@@ -7,4 +7,9 @@
                                      [index]="index"
                                      [linkType]="linkType"
                                      [listID]="listID"></ds-listable-object-component-loader>
-<ds-workflow-item-admin-workflow-actions-element [wfi]="dso" [small]="false"></ds-workflow-item-admin-workflow-actions-element>
+<ds-workflow-item-admin-workflow-actions-element
+        [wfi]="dso"
+        [small]="false"
+        [claimedTaskList]="claimedTasks$ | async"
+>
+</ds-workflow-item-admin-workflow-actions-element>

--- a/src/app/admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-list-element/workflow-item/workflow-item-search-result-admin-workflow-list-element.component.ts
+++ b/src/app/admin/admin-workflow-page/admin-workflow-search-results/admin-workflow-search-result-list-element/workflow-item/workflow-item-search-result-admin-workflow-list-element.component.ts
@@ -1,22 +1,9 @@
-import {
-  AsyncPipe,
-  NgIf,
-} from '@angular/common';
-import {
-  Component,
-  Inject,
-  OnInit,
-} from '@angular/core';
+import { AsyncPipe, NgIf, } from '@angular/common';
+import { Component, Inject, OnInit, } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  BehaviorSubject,
-  Observable,
-} from 'rxjs';
+import { BehaviorSubject, Observable, } from 'rxjs';
 
-import {
-  APP_CONFIG,
-  AppConfig,
-} from '../../../../../../config/app-config.interface';
+import { APP_CONFIG, AppConfig, } from '../../../../../../config/app-config.interface';
 import { DSONameService } from '../../../../../core/breadcrumbs/dso-name.service';
 import { LinkService } from '../../../../../core/cache/builders/link.service';
 import { RemoteData } from '../../../../../core/data/remote-data';
@@ -24,13 +11,16 @@ import { Context } from '../../../../../core/shared/context.model';
 import { Item } from '../../../../../core/shared/item.model';
 import {
   getFirstCompletedRemoteData,
+  getFirstSucceededRemoteDataPayload,
   getRemoteDataPayload,
 } from '../../../../../core/shared/operators';
 import { ViewMode } from '../../../../../core/shared/view-mode.model';
 import { WorkflowItem } from '../../../../../core/submission/models/workflowitem.model';
-import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import { WorkflowItemDataService } from '../../../../../core/submission/workflowitem-data.service';
+import { ClaimedTask } from '../../../../../core/tasks/models/claimed-task-object.model';
 import { ListableObjectComponentLoaderComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object-component-loader.component';
-import { WorkflowItemSearchResult } from '../../../../../shared/object-collection/shared/workflow-item-search-result.model';
+import { listableObjectComponent } from '../../../../../shared/object-collection/shared/listable-object/listable-object.decorator';
+import {  WorkflowItemSearchResult } from '../../../../../shared/object-collection/shared/workflow-item-search-result.model';
 import { SearchResultListElementComponent } from '../../../../../shared/object-list/search-result-list-element/search-result-list-element.component';
 import { TruncatableService } from '../../../../../shared/truncatable/truncatable.service';
 import { followLink } from '../../../../../shared/utils/follow-link-config.model';
@@ -47,17 +37,21 @@ import { WorkflowItemAdminWorkflowActionsComponent } from '../../actions/workflo
 /**
  * The component for displaying a list element for a workflow item on the admin workflow search page
  */
-export class WorkflowItemSearchResultAdminWorkflowListElementComponent extends SearchResultListElementComponent<WorkflowItemSearchResult, WorkflowItem> implements OnInit {
+export class WorkflowItemSearchResultAdminWorkflowListElementComponent
+  extends SearchResultListElementComponent<WorkflowItemSearchResult, WorkflowItem>
+  implements OnInit {
 
-  /**
-   * The item linked to the workflow item
-   */
+  /** The item linked to the workflow item */
   public item$: BehaviorSubject<Item> = new BehaviorSubject<Item>(undefined);
+  /** The claimed tasks linked to the workflow item */
+  public claimedTasks$: BehaviorSubject<ClaimedTask[]> = new BehaviorSubject<ClaimedTask[]>([]);
 
-  constructor(private linkService: LinkService,
-              protected truncatableService: TruncatableService,
-              public dsoNameService: DSONameService,
-              @Inject(APP_CONFIG) protected appConfig: AppConfig,
+  constructor(
+    private linkService: LinkService,
+    private workflowDataService: WorkflowItemDataService,
+    protected truncatableService: TruncatableService,
+    public dsoNameService: DSONameService,
+    @Inject(APP_CONFIG) protected appConfig: AppConfig,
   ) {
     super(truncatableService, dsoNameService, appConfig);
   }
@@ -67,12 +61,15 @@ export class WorkflowItemSearchResultAdminWorkflowListElementComponent extends S
    */
   ngOnInit(): void {
     super.ngOnInit();
+
     this.dso = this.linkService.resolveLink(this.dso, followLink('item'));
-    (this.dso.item as Observable<RemoteData<Item>>).pipe(
-      getFirstCompletedRemoteData(),
-      getRemoteDataPayload())
-      .subscribe((item: Item) => {
-        this.item$.next(item);
-      });
+    (this.dso.item as Observable<RemoteData<Item>>)
+      .pipe(getFirstCompletedRemoteData(), getRemoteDataPayload())
+      .subscribe((item: Item) => this.item$.next(item));
+
+    this.workflowDataService
+      .getClaimedTasks(this.dso.id)
+      .pipe(getFirstSucceededRemoteDataPayload())
+      .subscribe(data => this.claimedTasks$.next(data.page));
   }
 }

--- a/src/app/core/submission/models/submission-object.model.ts
+++ b/src/app/core/submission/models/submission-object.model.ts
@@ -20,6 +20,8 @@ import { HALLink } from '../../shared/hal-link.model';
 import { ITEM } from '../../shared/item.resource-type';
 import { SupervisionOrder } from '../../supervision-order/models/supervision-order.model';
 import { SUPERVISION_ORDER } from '../../supervision-order/models/supervision-order.resource-type';
+import { ClaimedTask } from '../../tasks/models/claimed-task-object.model';
+import { CLAIMED_TASK } from '../../tasks/models/claimed-task-object.resource-type';
 import { excludeFromEquals } from '../../utilities/equals.decorators';
 import { WorkspaceitemSectionsObject } from './workspaceitem-sections.model';
 
@@ -71,6 +73,7 @@ export abstract class SubmissionObject extends DSpaceObject implements Cacheable
     submissionDefinition: HALLink;
     submitter: HALLink;
     supervisionOrders: HALLink;
+    claimedTasks: HALLink;
   };
 
   get self(): string {
@@ -105,6 +108,13 @@ export abstract class SubmissionObject extends DSpaceObject implements Cacheable
    */
   @link(SUPERVISION_ORDER)
   /* This was changed from 'Observable<RemoteData<WorkspaceItem>> | WorkspaceItem' to 'any' to prevent issues in templates with async */
-    supervisionOrders?: Observable<RemoteData<PaginatedList<SupervisionOrder>>>;
+  supervisionOrders?: Observable<RemoteData<PaginatedList<SupervisionOrder>>>;
+
+  /**
+   * The claimed tasks related to this SubmissionObject
+   * Will be undefined unless the claimedTasks {@link HALLink} has been resolved.
+   */
+  @link(CLAIMED_TASK)
+  claimedTasks?: Observable<RemoteData<ClaimedTask>>;
 
 }

--- a/src/app/core/submission/workflowitem-data.service.ts
+++ b/src/app/core/submission/workflowitem-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import {
   find,
   map,
@@ -15,6 +15,7 @@ import {
   DeleteData,
   DeleteDataImpl,
 } from '../data/base/delete-data';
+import { FindAllDataImpl } from '../data/base/find-all-data';
 import { IdentifiableDataService } from '../data/base/identifiable-data.service';
 import {
   SearchData,
@@ -23,11 +24,12 @@ import {
 import { FindListOptions } from '../data/find-list-options.model';
 import { PaginatedList } from '../data/paginated-list.model';
 import { RemoteData } from '../data/remote-data';
-import { DeleteByIDRequest } from '../data/request.models';
+import { DeleteByIDRequest, GetRequest } from '../data/request.models';
 import { RequestService } from '../data/request.service';
 import { HALEndpointService } from '../shared/hal-endpoint.service';
 import { NoContent } from '../shared/NoContent.model';
 import { getFirstCompletedRemoteData } from '../shared/operators';
+import { ClaimedTask } from '../tasks/models/claimed-task-object.model';
 import { WorkflowItem } from './models/workflowitem.model';
 
 /**
@@ -49,7 +51,6 @@ export class WorkflowItemDataService extends IdentifiableDataService<WorkflowIte
     protected notificationsService: NotificationsService,
   ) {
     super('workflowitems', requestService, rdbService, objectCache, halService);
-
     this.searchData = new SearchDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, this.responseMsToLive);
     this.deleteData = new DeleteDataImpl(this.linkPath, requestService, rdbService, objectCache, halService, notificationsService, this.responseMsToLive, this.constructIdEndpoint);
   }
@@ -73,6 +74,15 @@ export class WorkflowItemDataService extends IdentifiableDataService<WorkflowIte
       getFirstCompletedRemoteData(),
       map((response: RemoteData<NoContent>) => response.hasSucceeded),
     );
+  }
+
+  getClaimedTasks(id: string): Observable<RemoteData<PaginatedList<ClaimedTask>>> {
+    const requestHref$ = this.getIDHrefObs(id)
+      .pipe(
+        map((endpoint: string) => endpoint + '/claimedTasks'),
+        find((endpoint: string) => hasValue(endpoint))
+      );
+    return this.rdbService.buildList(requestHref$);
   }
 
   /**

--- a/src/app/shared/search/search.component.ts
+++ b/src/app/shared/search/search.component.ts
@@ -694,6 +694,7 @@ export class SearchComponent implements OnDestroy, OnInit {
 
     if (this.configuration === 'supervision') {
       followLinks.push(followLink<WorkspaceItem>('supervisionOrders', { isOptional: true }) as any);
+      followLinks.push(followLink<WorkspaceItem>('claimedTasks', { isOptional: true }));
     }
 
     searchOptions = Object.assign(new PaginatedSearchOptions({}), searchOptions);

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -929,6 +929,12 @@
 
   "admin.workflow.item.supervision": "Supervision",
 
+  "admin.workflow.item.unassign": "Return to pool",
+
+  "admin.workflow.item.unassign.success": "Successfully returned to the pool",
+
+  "admin.workflow.item.unassign.error": "Error during return to the pool",
+
   "admin.metadata-import.breadcrumbs": "Import Metadata",
 
   "admin.batch-import.breadcrumbs": "Import Batch",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -1146,6 +1146,12 @@
   // "admin.workflow.item.supervision": "Supervision",
   "admin.workflow.item.supervision": "Supervision",
 
+  "admin.workflow.item.unassign": "Se désassigner",
+
+  "admin.workflow.item.unassign.success": "Opération réussie",
+
+  "admin.workflow.item.unassign.error": "Une erreur est survenue",
+
   // "admin.metadata-import.breadcrumbs": "Import Metadata",
   "admin.metadata-import.breadcrumbs": "Importer Métadonnées",
 


### PR DESCRIPTION
As administrator, using the worflow search interface, it's now possible to unassign a claimed task and return the workflow to the pool.

Authored-by: Renaud Michotte <renaud.michotte@uclouvain.be>
