### PR TITLE
[ADD] feat(journals) Journal management search, custom facets and journal item page

### DIFF
--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -5,6 +5,7 @@ export enum FeatureID {
   LoginOnBehalfOf = 'loginOnBehalfOf',
   AdministratorOf = 'administratorOf',
   HasRoleManager = 'hasRoleManager',
+  HasRoleJournalManager = 'hasRoleJournalManager',
   CanDelete = 'canDelete',
   CanEditMetadata = 'canEditMetadata',
   WithdrawItem = 'withdrawItem',
@@ -45,5 +46,5 @@ export enum FeatureID {
   CanViewInWorkflowSinceStatistics = 'canViewInWorkflowSinceStatistics',
   CanSeeComment = 'canSeeComment',
   CanCreateComment = 'canCreateComment',
-  CanDeleteComment = 'canDeleteComment'
+  CanDeleteComment = 'canDeleteComment',
 }

--- a/src/app/core/roles/role-types.ts
+++ b/src/app/core/roles/role-types.ts
@@ -1,5 +1,6 @@
 export enum RoleType {
   Submitter = 'submitter',
   Controller = 'controller',
+  JournalManager = 'journal-manager',
   Admin = 'admin'
 }

--- a/src/app/core/roles/role.service.ts
+++ b/src/app/core/roles/role.service.ts
@@ -64,6 +64,19 @@ export class RoleService {
   }
 
   /**
+   * Check if the user can manager journal items.
+   */
+  isJournalManager(): Observable<boolean> {
+    return this.authService
+      .getAuthenticatedUserFromStore()
+      .pipe(
+        switchMap(
+          (eperson: EPerson) => this.authorizationService.isAuthorized(FeatureID.HasRoleJournalManager, eperson.self)
+        ),
+      );
+  }
+
+  /**
    * Check if current user by role type
    *
    * @param {RoleType} role
@@ -77,6 +90,9 @@ export class RoleService {
         break;
       case RoleType.Controller:
         check = this.isController();
+        break;
+      case RoleType.JournalManager:
+        check = this.isJournalManager();
         break;
       case RoleType.Admin:
         check = this.isAdmin();

--- a/src/app/core/shared/listable.module.ts
+++ b/src/app/core/shared/listable.module.ts
@@ -126,6 +126,8 @@ import { ThumbnailComponent } from '../../thumbnail/thumbnail.component';
 import { PublicationListElementComponent } from 'src/themes/uclouvain/app/entity-groups/publication-entity/item-list-elements/publication-list-elements.component';
 import { PublicationSearchResultWrapperComponent } from 'src/themes/uclouvain/app/entity-groups/publication-entity/search-result-list-elements/publication-search-result/publicaton-search-result-wrapper.component.html/publication-search-result-wrapper.component';
 import { PublicationPageComponent } from 'src/themes/uclouvain/app/entity-groups/publication-entity/item-pages/publication-page.component';
+import { UCLouvainJournalSearchResultListElementComponent } from 'src/themes/uclouvain/app/entity-groups/journal-entity/search-result-list-element/journal-search-result-list-element.component';
+import { JournalPageComponent } from 'src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component';
 
 const ENTRY_COMPONENTS = [
   BitstreamListItemComponent,
@@ -215,6 +217,8 @@ const ENTRY_COMPONENTS = [
   PublicationListElementComponent,
   PublicationSearchResultWrapperComponent,
   PublicationPageComponent,
+  UCLouvainJournalSearchResultListElementComponent,
+  JournalPageComponent,
 ];
 
 @NgModule({

--- a/src/app/menu-resolver.service.ts
+++ b/src/app/menu-resolver.service.ts
@@ -2,8 +2,8 @@ import { isPlatformBrowser } from '@angular/common';
 import { Inject, Injectable, PLATFORM_ID, } from '@angular/core';
 import { ActivatedRoute, ActivatedRouteSnapshot, RouterStateSnapshot, } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { combineLatest as observableCombineLatest, mergeMap, Observable, of, } from 'rxjs';
-import { filter, find, map, switchMap, take, } from 'rxjs/operators';
+import { combineLatest as observableCombineLatest, mergeMap, Observable, of } from 'rxjs';
+import { filter, find, map, switchMap, take } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 import { PUBLICATION_CLAIMS_PATH } from './admin/admin-notifications/admin-notifications-routing-paths';
@@ -57,6 +57,7 @@ import { OnClickMenuItemModel } from './shared/menu/menu-item/models/onclick.mod
 import { TextMenuItemModel } from './shared/menu/menu-item/models/text.model';
 import { MenuState } from './shared/menu/menu-state.model';
 import { MenuService } from './shared/menu/menu.service';
+import { RoleService } from './core/roles/role.service';
 
 /**
  * Creates all the app's menus
@@ -78,6 +79,7 @@ export class MenuResolverService  {
     protected configurationDataService: ConfigurationDataService,
     protected sectionDataService: SectionDataService,
     protected configService: ConfigurationDataService,
+    protected roleService: RoleService,
   ) {
   }
 
@@ -202,6 +204,34 @@ export class MenuResolverService  {
     this.authService.isAuthenticated().subscribe(v => myDialLinkModel.visible = v);
     this.menuService.addSection(MenuID.PUBLIC, myDialLinkModel);
 
+    // Make the journal managing url visible if the user is a journal manager.
+    this.roleService.isJournalManager().subscribe(isJournalManager => {
+      if (!isJournalManager) {
+        return;
+      }
+
+      // Adds a manage journal section
+      const manageJournalsLinkModel = Object.assign(
+        {
+          id: `manage_journals`,
+          active: false,
+          visible: true,
+          index: 1,
+          model: {
+            type: MenuItemType.LINK,
+            disabled: false,
+            text: `menu.section.manage_journal`,
+            link: `/search`,
+            queryParams: {
+              ['configuration']: 'journals',
+            },
+          } as LinkMenuItemModel
+        },
+        {shouldPersistOnRouteChange: true}
+      );
+
+      this.menuService.addSection(MenuID.PUBLIC, manageJournalsLinkModel);
+    });
     return this.waitForMenu$(MenuID.PUBLIC);
   }
 

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -1275,6 +1275,8 @@
 
   "browse.metadata.rsoTitle": "Research Outputs Title",
 
+  "browse.metadata.publicationjournal": "Journal",
+
   "browse.metadata.author.breadcrumbs": "Browse by Author",
 
   "browse.metadata.dateissued.breadcrumbs": "Browse by Date",
@@ -1308,6 +1310,8 @@
   "browse.metadata.type.breadcrumbs": "Browse by Type",
 
   "browse.metadata.title.breadcrumbs": "Browse by Title",
+
+  "browse.metadata.publicationjournal.breadcrumbs": "Browse by Journal",
 
   "pagination.next.button": "Next",
 
@@ -3523,6 +3527,12 @@
 
   "item.orcid.return": "Back",
 
+  "item.identifier.dc.identifier.issn.copy.tooltip": "Copy ISSN",
+  "item.identifier.dc.identifier.eissn.copy.tooltip": "Copy e-ISSN",
+
+  "item.identifier.copy.success": "Identifier successfully copied to clipboard!",
+  "item.identifier.copy.error": "An error occurred, could not copy the identifier to the clipboard!",
+
   "item.listelement.badge": "Item",
 
   "item.page.comment.by": "By: ",
@@ -3534,11 +3544,21 @@
 
   "item.page.description": "Description",
 
+  "item.page.journal.type": "Journal",
+
   "item.page.journal-issn": "Journal ISSN",
+
+  "item.page.journal-eissn": "Journal e-ISSN",
 
   "item.page.journal-title": "Journal Title",
 
   "item.page.publisher": "Publisher",
+
+  "item.page.publisher.location": "Publisher location",
+
+  "item.page.peerreviewed": "Peer-reviewed",
+
+  "item.page.statuscode": "Status",
 
   "item.page.titleprefix": "Item: ",
 
@@ -4136,6 +4156,20 @@
 
   "journal.listelement.badge": "Journal",
 
+  "journal.listelement.status": "Status",
+
+  "journal.listelement.status.active": "Active",
+
+  "journal.listelement.status.ceased": "Ceased",
+
+  "journal.listelement.status.unknown": "Unknown",
+
+  "journal.listelement.peerreviewed": "Peer-reviewed",
+
+  "journal.listelement.peerreviewed.true": "Yes",
+
+  "journal.listelement.peerreviewed.false": "No",
+
   "journal.page.description": "Description",
 
   "journal.page.edit": "Edit this item",
@@ -4458,6 +4492,8 @@
   "menu.section.import_metadata": "Metadata",
 
   "menu.section.mydspace_shortcut": "MyDial.pr",
+
+  "menu.section.manage_journal": "Manage journals",
 
   "menu.section.new": "New",
 
@@ -5936,6 +5972,22 @@
 
   "search.filters.filter.accessType.placeholder": "Search an access type...",
 
+  "search.filters.filter.journalPublisher.head": "Publisher",
+
+  "search.filters.filter.journalPublisher.label": "Search a publisher",
+
+  "search.filters.filter.journalPublisher.placeholder": "Search for a publisher",
+
+  "search.filters.applied.f.journalPublisher": "Publisher",
+
+  "search.filters.filter.journalPeerReviewed.head": "Peer-reviewed",
+
+  "search.filters.applied.f.journalPeerReviewed": "Peer-reviewed",
+
+  "search.filters.filter.journalStatusCode.head": "Journal diffusion status",
+
+  "search.filters.applied.f.journalStatusCode": "Journal status",
+
   "search.filters.entityType.JournalIssue": "Journal Issue",
 
   "search.filters.entityType.JournalVolume": "Journal Volume",
@@ -6298,6 +6350,10 @@
   "form.other-information.miur.journal.enddate": "End Date",
 
   "form.other-information.dc.identifier.issn": "ISSN",
+
+  "form.other-information.journal.searchresult.info": "ISSN",
+
+  "form.other-information.journal.searchresult.ceased": "Status",
 
   "statistics.table.downloadReports.title.TotalVisits": "Most downloaded",
 
@@ -7758,6 +7814,8 @@
   "workflow.search.results.head": "Workflow tasks",
 
   "supervision.search.results.head": "Workflow and Workspace tasks",
+
+  "journals.search.results.head": "Journals",
 
   "orgunit.search.results.head": "Organizational Unit Search Results",
 

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -1405,6 +1405,9 @@
   // "browse.metadata.title": "Title",
   "browse.metadata.title": "Titre",
 
+  // "browse.metadata.publicationjournal": "Browse by Journal",
+  "browse.metadata.publicationjournal": "Parcourir par Revue",
+
   // "browse.metadata.author.breadcrumbs": "Browse by Author",
   "browse.metadata.author.breadcrumbs": "Parcourir par Auteur",
 
@@ -1416,6 +1419,9 @@
 
   // "browse.metadata.title.breadcrumbs": "Browse by Title",
   "browse.metadata.title.breadcrumbs": "Parcourir par Titre",
+
+  // "browse.metadata.publicationjournal.breadcrumbs": "Browse by Journal",
+  "browse.metadata.publicationjournal.breadcrumbs": "Parcourir par Revue",
 
   // "browse.next.button": "Next",
   "browse.next.button": "Suivant(e)",
@@ -1489,11 +1495,11 @@
   // "browse.startsWith.type_text": "Type the first few letters and click on the Browse button",
   "browse.startsWith.type_text": "Ou saisir les premières lettres puis cliquer sur le bouton « Parcourir »",
 
-  // "browse.title": "Browsing {{ collection }} by {{ field }} {{ value }}",
-  "browse.title": "Parcourir la collection {{ collection }} par {{ field }} {{ value }}",
+  // "browse.title": "Browsing by {{ field }}{{ startsWith }} {{ value }}",
+  "browse.title": "Parcourir par {{ field }}{{ startsWith }} {{ value }}",
 
-  //"browse.title.page": "Browsing {{ collection }} by {{ field }} {{ value }}",
-  "browse.title.page": "Parcourir la collection {{ collection }} par {{ field }} {{ value }}",
+  //"browse.title.page": "Browsing by {{ field }} {{ value }}",
+  "browse.title.page": "Parcourir par {{ field }} {{ value }}",
 
   //"search.browse.item-back": "Back to Results",
   "search.browse.item-back": "Retour aux résultats",
@@ -3850,6 +3856,18 @@
   // "item.edit.withdraw.success": "The item was withdrawn successfully",
   "item.edit.withdraw.success": "L'Item a été retiré avec succès",
 
+  // "item.identifier.dc.identifier.issn.copy.tooltip": "Copy ISSN",
+  "item.identifier.dc.identifier.issn.copy.tooltip": "Copier l'ISSN",
+
+  // "item.identifier.dc.identifier.eissn.copy.tooltip": "Copy e-ISSN",
+  "item.identifier.dc.identifier.eissn.copy.tooltip": "Copier l'e-ISSN",
+
+  // "item.identifier.copy.success": "Identifier successfully copied to clipboard!",
+  "item.identifier.copy.success": "Identifiant copié avec succès!",
+
+  // "item.identifier.copy.error": "An error occured, could not copy the identifier to the clipboard!",
+  "item.identifier.copy.error": "Une erreur c'est produite, l'identifiant n'a pas pu être copié!",
+
   // "item.listelement.badge": "Item",
   "item.listelement.badge": "Item",
 
@@ -3863,14 +3881,29 @@
   // "item.page.description": "Description",
   "item.page.description": "Description",
 
+  // "item.page.journal.type": "Journal",
+  "item.page.journal.type": "Revue",
+
   // "item.page.journal-issn": "Journal ISSN",
   "item.page.journal-issn": "ISSN de la revue",
+
+  // "item.page.journal-eissn": "Journal e-ISSN",
+  "item.page.journal-eissn": "e-ISSN de la revue",
 
   // "item.page.journal-title": "Journal Title",
   "item.page.journal-title": "Nom de la revue",
 
   // "item.page.publisher": "Publisher",
   "item.page.publisher": "Éditeur",
+
+  // "item.page.publisher.location": "Publisher location",
+  "item.page.publisher.location": "Localisation de l'éditeur",
+
+  // "item.page.peerreviewed": "Peer-reviewed",
+  "item.page.peerreviewed": "Validé par les pairs",
+
+  // "item.page.statuscode": "Status",
+  "item.page.statuscode": "Status",
 
   // "item.page.titleprefix": "Item: ",
   "item.page.titleprefix": "Item : ",
@@ -4234,6 +4267,27 @@
   // "journal.listelement.badge": "Journal",
   "journal.listelement.badge": "Revue",
 
+  // "journal.listelement.status": "Status",
+  "journal.listelement.status": "Status",
+
+  // "journal.listelement.status.active": "Active",
+  "journal.listelement.status.active": "Actif",
+
+  // "journal.listelement.status.ceased": "Ceased",
+  "journal.listelement.status.ceased": "Arrêté",
+
+  // "journal.listelement.status.unknown": "Unknown",
+  "journal.listelement.status.unknown": "Inconnu",
+
+  // "journal.listelement.peerreviewed": "Peer-reviewed",
+  "journal.listelement.peerreviewed": "Validé par les pairs",
+
+  // "journal.listelement.peerreviewed.true": "Yes",
+  "journal.listelement.peerreviewed.true": "Oui",
+
+  // "journal.listelement.peerreviewed.false": "No",
+  "journal.listelement.peerreviewed.false": "Non",
+
   // "journal.page.description": "Description",
   "journal.page.description": "Description",
 
@@ -4455,6 +4509,9 @@
 
   // "menu.section.mydspace_shortcut": "MyDial.pr",
   "menu.section.mydspace_shortcut": "MyDIAL.pr",
+
+  // "menu.section.manage_journal": "Manage journals",
+  "menu.section.manage_journal": "Gestions des revues",
 
   //"menu.section.reports": "Reports",
   "menu.section.reports": "Rapports",
@@ -5920,6 +5977,32 @@
 
   // "search.filters.filter.accessType.placeholder": "Access type",
   "search.filters.filter.accessType.placeholder": "Rechercher un type d'accès...",
+
+  "search.filters.filter.journalPublisher.head": "Éditeur",
+
+  "search.filters.filter.journalPublisher.label": "Rechercher un éditeur",
+
+  "search.filters.filter.journalPublisher.placeholder": "Rechercher un éditeur",
+
+  "search.filters.applied.f.journalPublisher": "Éditeur",
+
+  "search.filters.filter.journalPeerReviewed.head": "Validation par les pairs",
+
+  "search.filters.applied.f.journalPeerReviewed": "Validation par les pairs",
+
+  "search.filters.journalPeerReviewed.true": "Validé",
+
+  "search.filters.journalPeerReviewed.false": "Non-validé",
+
+  "search.filters.filter.journalStatusCode.head": "Status de diffusion du journal",
+
+  "search.filters.applied.f.journalStatusCode": "Status du journal",
+
+  "search.filters.journalStatusCode.Active": "Actif",
+
+  "search.filters.journalStatusCode.Ceased": "Arrêté",
+
+  "search.filters.journalStatusCode.Unknown": "Inconnu",
 
   // "search.filters.entityType.JournalIssue": "Journal Issue",
   "search.filters.entityType.JournalIssue": "Numéro de revue",
@@ -7495,6 +7578,9 @@
 
   //"supervision.search.results.head": "Workflow and Workspace tasks",
   "supervision.search.results.head": "Tableau de suivi et dépôts en cours",
+
+  // "journals.search.results.head": "Journals",
+  "journals.search.results.head": "Journaux",
 
   // "workflow-item.edit.breadcrumbs": "Edit workflowitem",
   "workflow-item.edit.breadcrumbs": "Éditer l'Item du Workflow",
@@ -9404,5 +9490,8 @@
   "languages.iso-639-2.other": "Autre",
 
   "from": "à partir du",
+
+  "form.other-information.journal.searchresult.info": "ISSN",
+  "form.other-information.journal.searchresult.ceased": "Status",
 }
 

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component.html
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component.html
@@ -1,0 +1,58 @@
+<div class="d-flex">
+  <ds-results-back-button *ngIf="showBackButton$ | async" [back]="back"/>
+  <ds-context-menu class="ml-auto" 
+                   [contextMenuObject]="object"
+                   [contextMenuObjectType]="DspaceObjectType.ITEM"/>
+</div>
+
+<div class="container my-3 p-0">
+  <article>
+    <!-- HEADER (Type + title) -->
+    <div class="mb-5">
+      <h3 class="text-muted m-0">{{ 'item.page.journal.type' | translate }}</h3>
+      <ds-item-page-title-field [item]="object" />
+    </div>
+    <!-- MAIN METADATA SECTION -->
+    <div>
+      <ds-item-page-heading [headerLabel]="'item.page.heading.details'"/>
+      <dl class="ml-1">
+        <ng-container *ngIf="object.hasMetadata('dc.publisher')">
+          <dt>{{ "item.page.publisher" | translate }}</dt>
+          <dd>
+            <ds-generic-item-page-field [item]="object" [fields]="['dc.publisher']"/>
+          </dd>
+        </ng-container>
+        <ng-container *ngIf="object.hasMetadata('dc.publisher.location')">
+          <dt>{{ "item.page.publisher.location" | translate }}</dt>
+          <dd>
+            <ds-generic-item-page-field [item]="object" [fields]="['dc.publisher.location']"/>
+          </dd>
+        </ng-container>
+        <ng-container *ngIf="object.hasMetadata('dc.identifier.issn')">
+          <dt>{{ "item.page.journal-issn" | translate }}</dt>
+          <dd>
+            <ds-generic-item-page-field [item]="object" [fields]="['dc.identifier.issn']"/>
+          </dd>
+        </ng-container>
+        <ng-container *ngIf="object.hasMetadata('dc.identifier.eissn')">
+          <dt>{{ "item.page.journal-eissn" | translate }}</dt>
+          <dd>
+            <ds-generic-item-page-field [item]="object" [fields]="['dc.identifier.eissn']"/>
+          </dd>
+        </ng-container>
+        <ng-container *ngIf="object.hasMetadata('journal.peerReviewed')">
+          <dt>{{ "item.page.peerreviewed" | translate }}</dt>
+          <dd>
+            <ds-journal-peer-reviewed [journal]="object"/>
+          </dd>
+        </ng-container>
+        <ng-container *ngIf="object.hasMetadata('journal.statusCode')">
+          <dt>{{ "item.page.statuscode" | translate }}</dt>
+          <dd>
+            <ds-generic-item-page-field [item]="object" [fields]="['journal.statusCode']"/>
+          </dd>
+        </ng-container>
+      </dl>
+    </div>
+  </article>
+</div>

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component.scss
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component.scss
@@ -1,0 +1,7 @@
+.title-container {
+  span {
+    margin-top: 1px;
+    flex-grow: 1;
+    border-color: var(--bs-gray-200) !important;
+  }
+}

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/item-pages/journal-page.component.ts
@@ -1,0 +1,48 @@
+import { AsyncPipe, NgIf, NgTemplateOutlet } from "@angular/common";
+import { Component, Input } from "@angular/core";
+import { TranslateModule } from "@ngx-translate/core";
+import { Context } from "src/app/core/shared/context.model";
+import { DSpaceObjectType } from "src/app/core/shared/dspace-object-type.model";
+import { ViewMode } from "src/app/core/shared/view-mode.model";
+import { GenericItemPageFieldComponent } from "src/app/item-page/simple/field-components/specific-field/generic/generic-item-page-field.component";
+import { ThemedItemPageTitleFieldComponent } from "src/app/item-page/simple/field-components/specific-field/title/themed-item-page-field.component";
+import { ItemComponent } from "src/app/item-page/simple/item-types/shared/item.component";
+import { ContextMenuComponent } from "src/app/shared/context-menu/context-menu.component";
+import { listableObjectComponent } from "src/app/shared/object-collection/shared/listable-object/listable-object.decorator";
+import { ThemedResultsBackButtonComponent } from "src/app/shared/results-back-button/themed-results-back-button.component";
+import { JournalPeerReviewedComponent } from "../specific-fields/journal-peer-reviewed.component";
+import { ItemPageHeadingComponent } from "../../../shared/item-page/item-page-heading.component";
+
+/**
+ * Item page rendered for the 'Journal' item type.
+ * It displays basic information such as title, publisher, identifiers, status and peer-reviewed state.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@listableObjectComponent('Journal', ViewMode.StandalonePage, Context.Any, 'uclouvain')
+@Component({
+  selector: 'ds-journal-page',
+  templateUrl: './journal-page.component.html',
+  styleUrl: './journal-page.component.scss',
+  standalone: true,
+  imports: [
+    ThemedResultsBackButtonComponent,
+    ContextMenuComponent,
+    ThemedItemPageTitleFieldComponent,
+    TranslateModule,
+    AsyncPipe,
+    NgIf,
+    GenericItemPageFieldComponent,
+    JournalPeerReviewedComponent,
+    NgTemplateOutlet,
+    ItemPageHeadingComponent,
+  ],
+})
+export class JournalPageComponent extends ItemComponent {
+  @Input() showLabel: boolean;
+  @Input() showMetrics: boolean;
+  @Input() viewMode: ViewMode;
+  @Input() showCorrection: boolean;
+
+  protected readonly DspaceObjectType = DSpaceObjectType;
+}

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/journal-entity-constants.ts
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/journal-entity-constants.ts
@@ -1,0 +1,2 @@
+export const JOURNAL_STATUS_CODE_CEASED = 'ceased';
+export const JOURNAL_STATUS_CODE_ACTIVE = 'active';

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/search-result-list-element/journal-search-result-list-element.component.html
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/search-result-list-element/journal-search-result-list-element.component.html
@@ -1,0 +1,45 @@
+<div class="d-flex flex-column">
+  <div class="mb-2 w-100 d-flex flex-row">
+    <div class="flex-grow-1">
+      <ds-badges [object]="dso" [showAccessStatus]="false" [context]="context" [displayType]="true"/>
+    </div>
+    <div>
+      <ds-journal-ceased-status-badge [item]="dso" />
+    </div>
+  </div>
+  <div class="d-flex flex-column flex-grow-1">
+    <!-- TITLE ==================================================== -->
+    <a *ngIf="linkType != linkTypes.None"
+       [target]="(linkType == linkTypes.ExternalLink) ? '_blank' : '_self'"
+       [attr.rel]="(linkType == linkTypes.ExternalLink) ? 'noopener noreferrer' : null"
+       [routerLink]="[itemPageRoute]"
+       [innerHTML]="[dso.firstMetadataValue('dc.title')]"
+       class="lead item-list-title dont-break-out"></a>
+    <div *ngIf="linkType == linkTypes.None"
+         class="lead item-list-title dont-break-out"
+         [innerHTML]="dso.firstMetadataValue('dc.title')"></div>
+    <!-- Publisher name && location -->
+    <ul class="mt-1 list-inline d-flex gapx-1">
+      <li *ngIf="publisher">{{ publisher }}</li>
+      <li *ngIf="publisherLocation">({{ publisherLocation }})</li>
+    </ul>
+    <!-- ISSN, e-ISSN, StatusCode && Peer-reviewed -->
+    <ul class="list-inline list-inline-with-divider m-0 mt-1">
+      <li *ngIf="issn">
+        <ds-item-identifier-display [fieldLabel]="'ISSN'"
+                                    [item]="dso"
+                                    [metadataField]="'dc.identifier.issn'"/>
+      </li>
+      <li *ngIf="eissn">
+        <ds-item-identifier-display [fieldLabel]="'e-ISSN'"
+                                    [item]="dso"
+                                    [metadataField]="'dc.identifier.eissn'"/>
+      </li>
+      <li>
+        {{ 'journal.listelement.peerreviewed' | translate }}:
+        <ds-journal-peer-reviewed [journal]="dso" [displayIcon]="true" [displayText]="false"/>
+      </li>
+
+    </ul>
+  </div>
+</div>

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/search-result-list-element/journal-search-result-list-element.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/search-result-list-element/journal-search-result-list-element.component.ts
@@ -1,0 +1,59 @@
+import { NgClass, NgIf } from "@angular/common";
+import { Component, OnInit } from "@angular/core";
+import { RouterLink } from "@angular/router";
+import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
+import { TranslateModule } from "@ngx-translate/core";
+import { Context } from "src/app/core/shared/context.model";
+import { ViewMode } from "src/app/core/shared/view-mode.model";
+import { ThemedBadgesComponent } from "src/app/shared/object-collection/shared/badges/themed-badges.component";
+import { listableObjectComponent } from "src/app/shared/object-collection/shared/listable-object/listable-object.decorator";
+import { ItemSearchResultListElementComponent } from "src/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component";
+import { JournalPeerReviewedComponent } from "../specific-fields/journal-peer-reviewed.component";
+import { ItemIdentifierDisplayComponent } from "../../../shared/item-idenitfier-display/item-identifier-display.component";
+import { JournalCeasedStatusBadge } from "../specific-fields/journal-ceased-status-badge.component";
+
+/**
+ * Search result element to display for 'Journal' items.
+ * It displays all the informations about the journal: Title, publisher, identifiers, status and peer-reviewed state.
+ * This component needs to be rendered for Journals in workspace state and in the global search (see decorator below).
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@listableObjectComponent('JournalSearchResult', ViewMode.ListElement, Context.Search, 'uclouvain')
+@listableObjectComponent('JournalSearchResult', ViewMode.ListElement, Context.MyDSpaceWorkspace, 'uclouvain')
+@Component({
+  selector: 'ds-journal-search-result-list-element',
+  templateUrl: './journal-search-result-list-element.component.html',
+  standalone: true,
+  imports: [
+    RouterLink,
+    NgIf,
+    NgClass,
+    NgbTooltipModule,
+    ThemedBadgesComponent,
+    TranslateModule,
+    JournalPeerReviewedComponent,
+    ItemIdentifierDisplayComponent,
+    JournalCeasedStatusBadge,
+  ],
+})
+export class UCLouvainJournalSearchResultListElementComponent extends ItemSearchResultListElementComponent implements OnInit {
+
+  // Metadata to display
+  protected publisher: string;
+  protected publisherLocation: string;
+  protected issn: string;
+  protected eissn: string;
+  protected status: string;
+  protected peerReviewed: boolean;
+
+  ngOnInit(): void {
+    super.ngOnInit();
+    this.publisher = this.dso.firstMetadataValue('dc.publisher');
+    this.publisherLocation = this.dso.firstMetadataValue('dc.publisher.location');
+    this.issn = this.dso.firstMetadataValue('dc.identifier.issn');
+    this.eissn = this.dso.firstMetadataValue('dc.identifier.eissn');
+    this.status = this.dso.firstMetadataValue('journal.statusCode');
+    this.peerReviewed = this.dso.firstMetadataValue('journal.peerReviewed') === 'true';
+  }
+}

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/specific-fields/journal-ceased-status-badge.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/specific-fields/journal-ceased-status-badge.component.ts
@@ -1,0 +1,37 @@
+import { NgIf } from "@angular/common";
+import { Component, Input, OnInit } from "@angular/core";
+import { TranslateModule } from "@ngx-translate/core";
+import { Item } from "src/app/core/shared/item.model";
+import { JOURNAL_STATUS_CODE_CEASED } from "../journal-entity-constants";
+
+/**
+ * Displays a badge when the journal status is 'ceased'.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Component({
+  selector: 'ds-journal-ceased-status-badge',
+  template: `
+    <div *ngIf="isCeased"
+         class="badge rounded text-white p-2 m-0">
+      <i class="fa-solid fa-triangle-exclamation"></i>
+      <span>
+        {{ 'journal.listelement.status.ceased' | translate }}
+      </span>
+    </div>
+  `,
+  // Using direct var(--bs-danger) to match the other danger icons (peer-review) color.
+  styles: ['.badge { background-color: var(--bs-danger);}'],
+  standalone: true,
+  imports: [TranslateModule, NgIf],
+})
+export class JournalCeasedStatusBadge implements OnInit {
+  @Input() item: Item;
+
+  protected isCeased: boolean;
+  protected readonly statusField = 'journal.statusCode';
+
+  ngOnInit(): void {
+    this.isCeased = this.item.firstMetadataValue(this.statusField)?.toLowerCase() === JOURNAL_STATUS_CODE_CEASED;
+  }
+}

--- a/src/themes/uclouvain/app/entity-groups/journal-entity/specific-fields/journal-peer-reviewed.component.ts
+++ b/src/themes/uclouvain/app/entity-groups/journal-entity/specific-fields/journal-peer-reviewed.component.ts
@@ -1,0 +1,50 @@
+import { NgClass, NgIf } from "@angular/common";
+import { Component, Input, OnInit } from "@angular/core";
+import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
+import { TranslateModule } from "@ngx-translate/core";
+import { Item } from "src/app/core/shared/item.model";
+
+/**
+ * Specific journal field to render the peer reviewed state of the journal.
+ * It handles the displayed color and the i18n text depending on the value of the metadata.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Component({
+  selector: 'ds-journal-peer-reviewed',
+  template: `
+    <span *ngIf="displayIcon || displayText">
+      <i *ngIf="displayIcon" class="fa-solid" [ngClass]="{
+        'fa-circle-check peer-reviewed': peerReviewed,
+        'fa-circle-xmark not-peer-reviewed':!peerReviewed
+      }"></i>
+      <span *ngIf="displayText">
+        {{ ('journal.listelement.peerreviewed.' + peerReviewed) | translate }}
+      </span>
+    </span>
+  `,
+  styles: [`
+    .peer-reviewed { color: var(--ds-dark-green); }
+    .not-peer-reviewed { color: var(--bs-danger); }
+  `],
+  standalone: true,
+  imports: [
+    NgClass,
+    TranslateModule,
+    NgIf,
+    NgbTooltipModule,
+  ]
+})
+export class JournalPeerReviewedComponent implements OnInit {
+  @Input() journal: Item;
+  @Input() displayIcon: boolean = false;
+  @Input() displayText: boolean = true;
+
+  protected peerReviewed: boolean;
+  protected readonly peerReviewedField = 'journal.peerReviewed';
+  
+  ngOnInit(): void {
+    // Retrieve the metadata value. If none found, use 'false' by default.
+    this.peerReviewed = this.journal.firstMetadataValue(this.peerReviewedField)?.toLowerCase() === 'true';
+  }
+}

--- a/src/themes/uclouvain/app/shared/item-idenitfier-display/item-identifier-display.component.ts
+++ b/src/themes/uclouvain/app/shared/item-idenitfier-display/item-identifier-display.component.ts
@@ -1,0 +1,68 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { NgbTooltipModule } from "@ng-bootstrap/ng-bootstrap";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { Item } from "src/app/core/shared/item.model";
+import { NotificationsService } from "src/app/shared/notifications/notifications.service";
+
+/**
+ * Custom component to render an item identifier.
+ * The component allows to copy the value of the id by clicking it.
+ * 
+ * @input fieldLabel The label to display for this identifier.
+ * @input item The item to extract the metadata value from.
+ * @input metadataField The field from which to extract the value to display.
+ * @input enableCopy Enables the copy of the value by clinking it (true by def.).
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Component({
+  selector: 'ds-item-identifier-display',
+  template: `
+    <div class="badge" [ngbTooltip]="tooltip | translate" (click)="copyIdentifier()">
+      <span class="font-weight-bold">
+        {{ fieldLabel }}:
+      </span>
+      <span>
+        {{ metadataValue }}
+      </span>
+    </div>
+  `,
+  styles: [`
+    .badge {
+      box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 1px;
+      cursor: pointer;
+    }
+  `],
+  standalone: true,
+  imports: [
+    NgbTooltipModule,
+    TranslateModule,
+  ],
+})
+export class ItemIdentifierDisplayComponent implements OnInit {
+  @Input() fieldLabel: string;
+  @Input() item: Item;
+  @Input() metadataField: string;
+  @Input() enableCopy = true;
+
+  protected metadataValue: string;
+  protected tooltip: string;
+
+  constructor(
+    protected notificationsService: NotificationsService,
+    protected translateService: TranslateService,
+  ) {}
+
+  ngOnInit(): void {
+    this.metadataValue = this.item.firstMetadataValue(this.metadataField);
+    this.tooltip = 'item.identifier.' + this.metadataField + '.copy.tooltip';
+  }
+
+  copyIdentifier(): void {
+    navigator.clipboard.writeText(this.metadataValue).then(() => {
+      this.notificationsService.success(this.translateService.get('item.identifier.copy.success'));
+    }).catch((error) => {
+      this.notificationsService.error(this.translateService.get('item.identifier.copy.error') + error);
+    })
+  }
+} 


### PR DESCRIPTION
- New link in the navbar for journal managers. The link is only visible for people with the role 'journal-manager' or 'administrator'. When clicking the link, we go to a search page using the 'journals' configuration. This view allows to search in all the existing journals.
- Customized the facets in the journals search section.
- Added a new page for the 'journal' item type.