### PR TITLE
[ADD] feat(journals) New way to delete journals for managers.

### DIFF
--- a/src/app/shared/context-menu/context-menu-entry-type.ts
+++ b/src/app/shared/context-menu/context-menu-entry-type.ts
@@ -14,4 +14,5 @@ export enum ContextMenuEntryType {
   ItemVersion = 'itemversion',
   FullItem = 'fullitem',
   OrcidView = 'orcidview',
+  DeleteJournal = 'deletejournal',
 }

--- a/src/app/shared/context-menu/context-menu.decorator.ts
+++ b/src/app/shared/context-menu/context-menu.decorator.ts
@@ -16,6 +16,7 @@ import { RequestCorrectionMenuComponent } from './request-correction/request-cor
 import { StatisticsMenuComponent } from './statistics/statistics-menu.component';
 import { SubscriptionMenuComponent } from './subscription/subscription-menu.component';
 import { CommentItemMenuComponent } from './comment-item/comment-item-menu.component';
+import { DeleteJournalMenuComponent } from './delete-journal/delete-journal-menu.component';
 
 export interface ContextMenuEntryRenderOptions {
   componentRef: GenericConstructor<ContextMenuEntryComponent>;
@@ -76,6 +77,10 @@ contextMenuEntriesMap.set(DSpaceObjectType.ITEM, [
   {
     componentRef: CommentItemMenuComponent,
     isStandAlone: false
+  },
+  {
+    componentRef: DeleteJournalMenuComponent,
+    isStandAlone: false,
   }
 ]);
 contextMenuEntriesMap.set(DSpaceObjectType.COMMUNITY, [

--- a/src/app/shared/context-menu/delete-journal/delete-journal-menu.component.html
+++ b/src/app/shared/context-menu/delete-journal/delete-journal-menu.component.html
@@ -1,0 +1,28 @@
+<button *ngIf="(isAuthorized$ | async)"
+        class="dropdown-item"
+        [innerHTML]="'item.journal.delete.menu' | translate"
+        (click)="openConfirmModal(confirmDeleteModal)">
+</button>
+
+<ng-template #confirmDeleteModal let-c="close" let-d="dismiss">
+  <div class="modal-header">
+    <h4 class="modal-title">{{ 'item.journal.delete.header' | translate }}</h4>
+    <button type="button"
+            class="close"
+            aria-label="Close"
+            (click)="d('Cross click')">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="modal-body">
+    <div class="alert alert-danger" role="alert">
+      {{ 'item.journal.delete.confirm.message' | translate }}
+    </div>
+    <button id="btn-chat"
+            class="btn btn-danger btn-lg btn-block mt-3"
+            (click)="deleteJournal()">
+      <span *ngIf="processing$ | async"><i class='fas fa-circle-notch fa-spin'></i>{{ 'item.journal.delete.button.loading' | translate }}</span>
+      <span *ngIf="!(processing$ | async)">{{ 'item.journal.delete.button' | translate }}</span>
+    </button>
+  </div>
+</ng-template>

--- a/src/app/shared/context-menu/delete-journal/delete-journal-menu.component.ts
+++ b/src/app/shared/context-menu/delete-journal/delete-journal-menu.component.ts
@@ -1,0 +1,113 @@
+import { Component, Inject, OnDestroy, OnInit } from "@angular/core";
+import { ContextMenuEntryComponent } from "../context-menu-entry.component";
+import { DSpaceObject } from "src/app/core/shared/dspace-object.model";
+import { DSpaceObjectType } from "src/app/core/shared/dspace-object-type.model";
+import { RoleService } from "src/app/core/roles/role.service";
+import { ContextMenuEntryType } from "../context-menu-entry-type";
+import { AuthorizationDataService } from "src/app/core/data/feature-authorization/authorization-data.service";
+import { BehaviorSubject, combineLatest, map, Observable, of, Subscription, tap } from "rxjs";
+import { FeatureID } from "src/app/core/data/feature-authorization/feature-id";
+import { TranslateModule, TranslateService } from "@ngx-translate/core";
+import { AsyncPipe, NgIf } from "@angular/common";
+import { NgbModal, NgbModalRef } from "@ng-bootstrap/ng-bootstrap";
+import { ItemDataService } from "src/app/core/data/item-data.service";
+import { getFirstCompletedRemoteData } from "src/app/core/shared/operators";
+import { NoContent } from "src/app/core/shared/NoContent.model";
+import { RemoteData } from "src/app/core/data/remote-data";
+import { NotificationsService } from "../../notifications/notifications.service";
+import { Router } from "@angular/router";
+import { isNotEmpty } from "../../empty.util";
+import { Item } from "src/app/core/shared/item.model";
+
+/**
+ * Component to display a context menu entry to delete a journal object.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+@Component({
+  selector: 'ds-delete-journal-menu',
+  templateUrl: './delete-journal-menu.component.html',
+  standalone: true,
+  imports: [TranslateModule, NgIf, AsyncPipe],
+})
+export class DeleteJournalMenuComponent extends ContextMenuEntryComponent implements OnInit, OnDestroy {
+
+  private subscription = new Subscription();
+  protected isAuthorized$: Observable<boolean> = of(false);
+  protected modalRef: NgbModalRef; 
+  protected processing$: BehaviorSubject<boolean> = new BehaviorSubject(false);
+
+  constructor(
+    @Inject('contextMenuObjectProvider') protected injectedContextMenuObject: DSpaceObject,
+    @Inject('contextMenuObjectTypeProvider') protected injectedContextMenuObjectType: DSpaceObjectType,
+    protected roleService: RoleService,
+    protected authorizationService: AuthorizationDataService,
+    protected modalService: NgbModal,
+    protected itemService: ItemDataService,
+    protected notificationsService: NotificationsService,
+    protected router: Router,
+    protected translateService: TranslateService,
+  ) {
+    super(injectedContextMenuObject, injectedContextMenuObjectType, ContextMenuEntryType.DeleteJournal);
+  }
+
+  ngOnInit(): void {
+    // Check for permission to delete a journal
+    if (isNotEmpty(this.contextMenuObject) && (this.contextMenuObject instanceof Item)) {
+      this.isAuthorized$ = combineLatest([
+        this.isObjectValid(),
+        this.authorizationService.isAuthorized(FeatureID.CanDelete, this.contextMenuObject.self, undefined, false)
+      ]).pipe(
+        map(([valid, authorized]: [boolean, boolean]) => valid && authorized)
+      );
+    }
+  }
+
+  /**
+   * Checks that the object is an item and that the entity type is 'Journal'. 
+   * @returns True if Item of type Journal, false otherwise.
+   */
+  isObjectValid(): Observable<boolean> {
+    if (isNotEmpty(this.contextMenuObject) && (this.contextMenuObject instanceof Item)) {
+      let item = (this.contextMenuObject) as Item;
+      if (item?.entityType === "Journal") {
+        return of(true);
+      }
+    }
+    return of(false);
+  }
+
+  openConfirmModal(content: any): void {
+    this.modalRef = this.modalService.open(content);
+  }
+
+  closeConfirmModal(): void {
+    this.modalRef.close();
+  }
+
+  deleteJournal(): void {
+    // Toggle loading state.
+    this.processing$.next(true);
+    this.subscription = this.itemService.delete(this.contextMenuObject.id).pipe(
+      getFirstCompletedRemoteData(),
+      // Disable loading state.
+      tap(() => this.processing$.next(false)),
+      tap(response => this.handleResponse(response)),
+    ).subscribe();
+  }
+
+  handleResponse(response: RemoteData<NoContent>) {
+    if (response.hasSucceeded) {
+      this.closeConfirmModal();
+      this.notificationsService.success(this.translateService.get("item.journal.deleted.success"));
+      // TODO: Maybe there is a better way to navigate to the desired page ?
+      this.router.navigateByUrl("/search?configuration=journals");
+    } else {
+      this.notificationsService.error(this.translateService.get("item.journal.deleted.error"));
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3533,6 +3533,14 @@
   "item.identifier.copy.success": "Identifier successfully copied to clipboard!",
   "item.identifier.copy.error": "An error occurred, could not copy the identifier to the clipboard!",
 
+  "item.journal.delete.button": "Delete journal",
+  "item.journal.delete.button.loading": "Processing journal deletion...",
+  "item.journal.delete.confirm.message": "Are you sure you want to delete this journal ? The journal object will be lost forever.",
+  "item.journal.delete.header": "Delete journal",
+  "item.journal.delete.menu": "Delete journal",
+  "item.journal.deleted.success": "Journal successfully deleted!",
+  "item.journal.deleted.error": "Could not delete journal. It might be a permission issue, check with the system administrator.",
+
   "item.listelement.badge": "Item",
 
   "item.page.comment.by": "By: ",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -3889,6 +3889,14 @@
   // "item.identifier.copy.error": "An error occured, could not copy the identifier to the clipboard!",
   "item.identifier.copy.error": "Une erreur c'est produite, l'identifiant n'a pas pu être copié!",
 
+  "item.journal.delete.button": "Supprimer la revue",
+  "item.journal.delete.button.loading": "Suppression en cours...",
+  "item.journal.delete.confirm.message": "Êtes-vous sûr de vouloir supprimer cette revue? Toutes les données liées seront perdues.",
+  "item.journal.delete.header": "Supprimer la revue",
+  "item.journal.delete.menu": "Supprimer la revue",
+  "item.journal.deleted.success": "Revue supprimée avec succès!",
+  "item.journal.deleted.error": "Erreur lors de la suppression de la revue! Cela pourrait être dû à un manque de permission, vérifier auprès de l'adinistrateur système.",
+
   // "item.listelement.badge": "Item",
   "item.listelement.badge": "Item",
 


### PR DESCRIPTION
Added a new menu section in the item page that allows the managers to delete a journal. This menu is only visible if the user has 'remove' permission on the collection and 'delete' permission on the item. (as described in 'canDelete' feature)