### PR TITLE
[UPD] feat(form): Clear authority when root data changes.

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/dynamic-vocabulary.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/dynamic-vocabulary.component.ts
@@ -1,9 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, Input, Output, } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import {
@@ -13,32 +8,22 @@ import {
   DynamicFormLayoutService,
   DynamicFormValidationService,
 } from '@ng-dynamic-forms/core';
-import {
-  Observable,
-  of as observableOf,
-} from 'rxjs';
-import {
-  distinctUntilChanged,
-  filter,
-  map,
-  take,
-} from 'rxjs/operators';
+import { Observable, of as observableOf, } from 'rxjs';
+import { distinctUntilChanged, filter, map, take, } from 'rxjs/operators';
+import { ConfidenceType } from 'src/app/core/shared/confidence-type';
 
 import { Metadata } from '../../../../../core/shared/metadata.utils';
 import { getFirstSucceededRemoteDataPayload } from '../../../../../core/shared/operators';
 import { PageInfo } from '../../../../../core/shared/page-info.model';
 import { SubmissionScopeType } from '../../../../../core/submission/submission-scope-type';
-import { Vocabulary } from '../../../../../core/submission/vocabularies/models/vocabulary.model';
 import { VocabularyEntry } from '../../../../../core/submission/vocabularies/models/vocabulary-entry.model';
+import { Vocabulary } from '../../../../../core/submission/vocabularies/models/vocabulary.model';
 import { VocabularyService } from '../../../../../core/submission/vocabularies/vocabulary.service';
 import { SubmissionService } from '../../../../../submission/submission.service';
+import { hasNoValue, hasValue, isEmpty, isNotEmpty, isUndefined, } from '../../../../empty.util';
 import {
-  hasValue,
-  isEmpty,
-  isUndefined,
-  isNotEmpty,
-} from '../../../../empty.util';
-import { VocabularyExternalSourceComponent } from '../../../../vocabulary-external-source/vocabulary-external-source.component';
+  VocabularyExternalSourceComponent
+} from '../../../../vocabulary-external-source/vocabulary-external-source.component';
 import { FormBuilderService } from '../../form-builder.service';
 import { FormFieldMetadataValueObject } from '../../models/form-field-metadata-value.model';
 import { DsDynamicInputModel } from './ds-dynamic-input.model';
@@ -297,6 +282,31 @@ export abstract class DsDynamicVocabularyComponent extends DynamicFormControlCom
         this.createChangeEventOnUpdate(updatedModels);
       }
     }
+  }
+
+  /**
+   * Clear other fields authority informations when this authority is invalidated (because of user modification).
+   * @param authority The authority to invalidate.
+   */
+  clearAuthorityInformation(authority: string): void {
+    if (hasNoValue(authority)) return;
+
+    const models = this.formBuilderService.getModelsByAuthority(authority);
+
+    models.map(model => ({model, existingValue: this.getModelAuthorityValue(model)}))
+    .filter(({existingValue}) => hasValue(existingValue))
+    .forEach(({model, existingValue}) => {
+      const newValue = Object.assign(new FormFieldMetadataValueObject(), existingValue);
+      newValue.authority = null;
+      newValue.confidence = ConfidenceType.CF_UNSET;
+      this.formBuilderService.updateModelValue(model.id, newValue);
+    })
+    this.createChangeEventOnUpdate(models);
+  }
+
+  getModelAuthorityValue(model: any): FormFieldMetadataValueObject {
+    const value = model?.metadataValue ?? model?.value;
+    return (value instanceof FormFieldMetadataValueObject) ? value : undefined;
   }
 
   protected createChangeEventOnUpdate(models: DynamicFormControlModel[]) {

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
@@ -236,12 +236,17 @@ export class DsDynamicOneboxComponent extends DsDynamicVocabularyComponent imple
    * @param event
    */
   onInput(event) {
+    const previousValue = this.model.value;
     if (!this.model.vocabularyOptions.closed && isNotEmpty(event.target.value)) {
       this.inputValue = new FormFieldMetadataValueObject(event.target.value);
       if (this.model.value) {
         if ((this.model.value as any).securityLevel != null) {
           this.inputValue.securityLevel = (this.model.value as any).securityLevel;
         }
+      }
+      // Invalidate all fields linked to the previous authority.
+      if (hasValue(previousValue) && previousValue.hasOwnProperty('authority')) {
+        this.clearAuthorityInformation(previousValue['authority']);
       }
     }
   }

--- a/src/app/shared/form/builder/form-builder.service.ts
+++ b/src/app/shared/form/builder/form-builder.service.ts
@@ -72,6 +72,7 @@ import { DYNAMIC_FORM_CONTROL_TYPE_TAG } from './ds-dynamic-form-ui/models/tag/d
 import { FormFieldMetadataValueObject } from './models/form-field-metadata-value.model';
 import { RowParser } from './parsers/row-parser';
 import { DynamicHiddenModel } from './ds-dynamic-form-ui/models/hidden/dynamic-hidden.model';
+import { DynamicRowGroupModel } from './ds-dynamic-form-ui/models/ds-dynamic-row-group-model';
 
 @Injectable({ providedIn: 'root' })
 export class FormBuilderService extends DynamicFormService {
@@ -596,6 +597,32 @@ export class FormBuilderService extends DynamicFormService {
     if (this.formGroups.has(id)) {
       this.formGroups.delete(id);
     }
+  }
+
+  /**
+   * Get an array of all models that use the given authority.
+   * @param authority The authority to lookup for.
+   * @returns An array of all models using the provided authority key.
+   */
+  getModelsByAuthority(authority: string): DynamicFormControlModel[] {
+    if (!authority) {
+      return [];
+    }
+
+    return Array.from(this.formModels.values())
+      // equivalent to 'flatMap' to flattent the top level arrays.
+      .reduce((acc, models) => acc.concat(models), [] as DynamicFormControlModel[])
+      // keep only the models that are DynamicRowGroupModel
+      .filter(model => model instanceof DynamicRowGroupModel)
+      // One more reduce ('flatMap' equivalent) to retrieve the models inside the groupModel.
+      .reduce((acc, rowGroup: DynamicRowGroupModel) => acc.concat(rowGroup.group), [] as DynamicFormControlModel[])
+      // Last filter to keep only valid authority linked models.
+      .filter(model => this.hasAuthority(model, authority))
+  }
+
+  private hasAuthority(model: any, authority: string) {
+    return model?.metadataValue?.authority === authority
+      || model?.value?.authority === authority;
   }
 
   /**


### PR DESCRIPTION
When a authority controlled field loses its authority due to user changes, all fields linked to this authority are cleared.

For example, when an author name is modified, the field loses its authority value: our system will know that and will update all the fields that have this authority value (email, orcid and affiliation) and remove the authority from their model.