### PR TITLE
[ADD] feat(onebox-select): Possibility to customize the result list of a onebox field.

### DIFF
--- a/src/app/core/submission/vocabularies/models/vocabulary-entry.model.ts
+++ b/src/app/core/submission/vocabularies/models/vocabulary-entry.model.ts
@@ -58,6 +58,12 @@ export class VocabularyEntry extends ListableObject {
   @autoserialize
   public type: any;
 
+  @autoserialize
+  public source: string;
+
+  @autoserialize
+  uniqueType: string;
+
   /**
    * The {@link HALLink}s for this ExternalSourceEntry
    */

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.html
@@ -1,8 +1,5 @@
 <ng-template #rt let-listEntry="result" let-t="term">
-  <ng-container
-    [ngTemplateOutlet]="(listEntry.hasOtherInformation()) ? hasInfo : noInfo"
-    [ngTemplateOutletContext]="{entry: listEntry}">
-  </ng-container>
+  <ds-onebox-result-element-loader [data]="listEntry" [metadataField]="model.name"/>
 </ng-template>
 
 <ng-template #hasInfo let-entry="entry">

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.scss
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.scss
@@ -5,10 +5,12 @@
   max-height: var(--ds-dropdown-menu-max-height);
   overflow-y: auto !important;
   overflow-x: hidden;
+  z-index: 998 !important;
 }
 
 :host ::ng-deep .dropdown-item {
   border-bottom: var(--bs-dropdown-border-width) solid var(--bs-dropdown-border-color);
+  padding: 0;
 }
 
 :host ::ng-deep .dropdown-item.active,

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/dynamic-onebox.component.ts
@@ -1,5 +1,6 @@
 import {
   AsyncPipe,
+  JsonPipe,
   NgForOf,
   NgIf,
   NgTemplateOutlet,
@@ -8,6 +9,8 @@ import {
   ChangeDetectorRef,
   Component,
   EventEmitter,
+  forwardRef,
+  InjectionToken,
   Input,
   OnDestroy,
   OnInit,
@@ -76,6 +79,9 @@ import { FormBuilderService } from '../../../form-builder.service';
 import { FormFieldMetadataValueObject } from '../../../models/form-field-metadata-value.model';
 import { DsDynamicVocabularyComponent } from '../dynamic-vocabulary.component';
 import { DynamicOneboxModel } from './dynamic-onebox.model';
+import { OneboxResultElementComponentLoader } from './onebox-result-element/onebox-result-element-loader.component';
+
+export const ONEBOX_TYPEAHEAD_SELECT_HANDLER = new InjectionToken<(entry: any) => void>('TYPEAHEAD_SELECT_HANDLER');
 
 /**
  * Component representing a onebox input field.
@@ -97,6 +103,16 @@ import { DynamicOneboxModel } from './dynamic-onebox.model';
     FormsModule,
     BtnDisabledDirective,
     NgbTooltipModule,
+    OneboxResultElementComponentLoader,
+  ],
+  providers: [
+    {
+      // This provider allows to trigger the selection method (onSelectItem) from the loader component.
+      // This is mandatory to reproduce the correct behavior of the 'NgbTypeahead' component. 
+      provide: ONEBOX_TYPEAHEAD_SELECT_HANDLER,
+      useFactory: (parent: DsDynamicOneboxComponent) => (event: NgbTypeaheadSelectItemEvent) => parent.onSelectItem(event),
+      deps: [forwardRef(() => DsDynamicOneboxComponent)]
+    }
   ],
   standalone: true,
 })
@@ -301,6 +317,9 @@ export class DsDynamicOneboxComponent extends DsDynamicVocabularyComponent imple
   onSelectItem(event: NgbTypeaheadSelectItemEvent) {
     this.inputValue = null;
     const item = event.item;
+
+    // Make sure the modal is closed when an item has been selected.
+    this.instance.dismissPopup();
 
     if ( hasValue(item.otherInformation)) {
       // Do not process keys starting with either 'data' or 'authority' as they are used for field autocomplete purpose only.

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/abstract-onebox-result-element.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/abstract-onebox-result-element.component.ts
@@ -1,0 +1,53 @@
+import { Component, Input } from "@angular/core";
+import { VocabularyEntry } from "src/app/core/submission/vocabularies/models/vocabulary-entry.model";
+import { isNotEmpty } from "src/app/shared/empty.util";
+
+@Component({
+  template: `ds-abstract-onebox-result-element`,
+  standalone: true,
+})
+export class AbstractOneboxResultElement {
+  @Input() entry: VocabularyEntry;
+
+  protected readonly isNotEmpty = isNotEmpty;
+
+  /**
+   * Get the other information value removing the authority section (after the last ::)
+   * @param itemValue the initial item value
+   */
+  getOtherInfoValue(itemValue: string): string {
+    if (!itemValue || !itemValue.includes('::')) {
+      return itemValue;
+    }
+
+    if (itemValue.includes('|||')) {
+      let result = '';
+      const values = itemValue.split('|||').map(item => item.substring(0, item.lastIndexOf('::')));
+      const lastIndex = values.length - 1;
+      values.forEach((value, i) => result += i === lastIndex ? value : value + ' · ');
+      return result;
+    }
+
+    return itemValue.substring(0, itemValue.lastIndexOf('::'));
+  }
+
+  /**
+   * Get the otherInformation object as a Map.
+   */
+  get otherInformationAsMap() {
+    if (!this.entry?.hasOtherInformation()) {
+      new Map();
+    }
+    return new Map(Object.entries(this.entry.otherInformation));
+  }
+
+  /**
+   * For a given map, check if the given key is present and if the corresponding value is not empty.
+   * @param otherInfo The map to check for value.
+   * @param key The key to check for value.
+   * @returns True if the key is present and the value is not empty. False otherwise.
+   */
+  hasValue(otherInfo: Map<string, string>, key: string): boolean {
+    return otherInfo.has(key) && isNotEmpty(otherInfo.get(key));
+  }
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/default/default-onebox-result-element.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/default/default-onebox-result-element.component.html
@@ -1,0 +1,15 @@
+<ul class="list-unstyled mb-0 px-3 py-1">
+  <li class="list-item d-flex align-items-center">
+    <img *ngIf="entry.source" class="mr-2" #imgTag [src]="getAuthoritySourceIcon(entry.source, imgTag)" [attr.alt]="('form.entry.source.' + entry.source) | translate" />
+    <div class="text-truncate text-primary font-weight-bold">{{entry.value}}</div>
+    <div *ngIf="entry.source" class="ml-2 text-truncate text-secondary">{{ ('form.entry.source.' + entry.source) | translate}}</div>
+  </li>
+  <ng-container *ngIf="entry.hasOtherInformation()">
+    <ng-container *ngFor="let item of entry.otherInformation | dsObjNgFor">
+      <!-- Do not display keys starting with either 'data-' or 'authority-' as they are used for autocomplete purpose only. -->
+      <li *ngIf="!item.key.startsWith('data-') && !item.key.startsWith('authority-')" class="list-item text-truncate text-secondary"  >
+        {{ 'form.other-information.' + item.key | translate }} : {{item.value !== '' ? getOtherInfoValue(item.value) : ('form.other-information.not-available' | translate)}}
+      </li>
+    </ng-container>
+  </ng-container>
+</ul>

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/default/default-onebox-result-element.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/default/default-onebox-result-element.component.ts
@@ -1,0 +1,54 @@
+import { Component } from "@angular/core";
+import { NgFor, NgIf } from "@angular/common";
+import { ObjNgFor } from "src/app/shared/utils/object-ngfor.pipe";
+import { TranslateModule } from "@ngx-translate/core";
+import { AbstractOneboxResultElement } from "../abstract-onebox-result-element.component";
+import { hasValue } from "src/app/shared/empty.util";
+import { environment } from "src/environments/environment";
+
+/**
+ * Default component to use when no component is found for a specific metadata field.
+ * This uses the exact same display and logic as what is in 'dynamic-onebox.component.html'.
+ */
+@Component({
+  selector: 'ds-default-onebox-result-element',
+  templateUrl: './default-onebox-result-element.component.html',
+  styles: [".list-item img { height: 20px; }"],
+  standalone: true,
+  imports: [
+    NgIf,
+    ObjNgFor,
+    TranslateModule,
+    NgFor,
+  ],
+})
+export class DefaultOneboxResultElementComponent extends AbstractOneboxResultElement {
+  protected authorithyIcons = environment.submission.icons.authority.sourceIcons;
+  
+  /**
+   * Get configured icon for each authority source
+   * @param source
+   */
+  getAuthoritySourceIcon(source: string, image: HTMLElement): string {
+    if (hasValue(this.authorithyIcons)) {
+      const iconPath = this.authorithyIcons.find(icon => icon.source === source)?.path;
+
+      if (!hasValue(iconPath)) {
+        this.handleImgError(image);
+      }
+
+      return iconPath;
+    } else {
+      this.handleImgError(image);
+    }
+
+    return '';
+  }
+
+  /**
+   * Hide image on error
+   */
+  handleImgError(image: HTMLElement): void {
+    image.style.display = 'none';
+  }
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/onebox-result-element-decorator.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/onebox-result-element-decorator.ts
@@ -1,0 +1,57 @@
+import { hasValue, isEmpty, isNotEmpty } from "src/app/shared/empty.util";
+import { DefaultOneboxResultElementComponent } from "./default/default-onebox-result-element.component";
+
+/**
+ * Decorator used to customize the content of an 'dynamic-onebox' field selection option.
+ * For a specific metadata field, this decorator allows to define a component that should be used to render search results.
+ *
+ * How to use :
+ *   Add the decorator `@OneboxResultElementComponent('metadataField')`
+ *   on your custom component. The component needs a 'data' parameter in its constructor method.
+ *   This parameter will be injected using 'data' key and will contain useful information on the search result.
+ *
+ * Example:
+ * ```
+ *   @OneboxResultElementComponent('dc.contributor.author')
+ *   @Component({...})
+ *   export class MyCustomComponent {
+ *      data: any = null;
+ *      constructor(@Inject('data') inputData: any) {
+ *        this.data = inputData;
+ *      }
+ *   }
+ * ```
+ */
+
+const map = new Map();
+
+/**
+ * Decorator to list a component as usable to render the search results of all provided fields.
+ *
+ * @param metadataFields The metadata fields for which the component can be used.
+ */
+export function OneboxResultElementComponent(metadataFields: string[]) {
+  if (isEmpty(metadataFields)) return;
+  return function decorator(component: any) {
+    metadataFields.forEach(metadataField => {
+      const normalizedField = metadataField.toLowerCase();
+      if (hasValue(normalizedField) && !map.has(normalizedField)) {
+        map.set(normalizedField, component);
+      }
+    })
+  }
+}
+
+/**
+ * Get a specific component to render for a given metadata field.
+ * If no component are found for the given metadata field, return the default component (created by DSpace).
+ *  
+ * @param metadataField The metadata field to get a component for.
+ * @returns The component that corresponds to the given metadata field or the default component if not found.
+ */
+export function getOneboxResultElementComponent(metadataField: string) {
+  const normalizedField = (isNotEmpty(metadataField)) ? metadataField.toLowerCase() : null;
+  return (hasValue(normalizedField) && map.has(normalizedField))
+    ? map.get(normalizedField)
+    : DefaultOneboxResultElementComponent; 
+}

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/onebox-result-element-loader.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/onebox/onebox-result-element/onebox-result-element-loader.component.ts
@@ -1,0 +1,47 @@
+import { Component, Injector, Input } from "@angular/core";
+import { getOneboxResultElementComponent } from "./onebox-result-element-decorator";
+import { VarDirective } from "src/app/shared/utils/var.directive";
+import { NgComponentOutlet } from "@angular/common";
+import { VocabularyEntry } from "src/app/core/submission/vocabularies/models/vocabulary-entry.model";
+import { ONEBOX_TYPEAHEAD_SELECT_HANDLER } from "../dynamic-onebox.component";
+import { NgbTypeaheadSelectItemEvent } from "@ng-bootstrap/ng-bootstrap";
+
+/**
+ * Component to load a specific search result component for a given metadata field.
+ */
+@Component({
+    selector: 'ds-onebox-result-element-loader',
+    template: `
+      <ng-container *ngVar="getComponent(metadataField) as component">
+        <div (mousedown)="onSelect(data)">
+          <ng-container *ngComponentOutlet="component; inputs: {entry: data}"></ng-container>
+        </div> 
+      </ng-container>
+    `,
+    standalone: true,
+    imports: [
+      VarDirective,
+      NgComponentOutlet,
+    ],
+})
+export class OneboxResultElementComponentLoader {
+  @Input() data: VocabularyEntry;
+  @Input() metadataField: string;
+
+  constructor(private injector: Injector){}
+
+  getComponent(metadataField: string) {
+    return getOneboxResultElementComponent(metadataField);
+  }
+
+  /**
+   * Propagate an event when the entry selected by the user.
+   * This has to be done because component injection breaks the normal behavior of ngbTypeahead.
+   * 
+   * @param entry The entry to send a selection event for.
+   */
+  onSelect(entry: VocabularyEntry) {
+    const event: NgbTypeaheadSelectItemEvent<VocabularyEntry> = { item: entry, preventDefault: () => {} };
+    this.injector.get<any>(ONEBOX_TYPEAHEAD_SELECT_HANDLER)?.(event);
+  }
+}

--- a/src/styles/_bootstrap_variables_mapping.scss
+++ b/src/styles/_bootstrap_variables_mapping.scss
@@ -527,7 +527,7 @@
   --bs-dropdown-box-shadow: #{$dropdown-box-shadow};
   --bs-dropdown-link-color: #{$dropdown-link-color};
   --bs-dropdown-link-hover-color: #{$dropdown-link-hover-color};
-  --bs-dropdown-link-hover-bg: #{$dropdown-link-hover-bg};
+  --bs-dropdown-link-hover-bg: var(--bs-gray-100); // #{$dropdown-link-hover-bg};
   --bs-dropdown-link-active-color: #{$dropdown-link-active-color};
   --bs-dropdown-link-active-bg: #{$dropdown-link-active-bg};
   --bs-dropdown-link-disabled-color: #{$dropdown-link-disabled-color};

--- a/src/styles/_custom_variables.scss
+++ b/src/styles/_custom_variables.scss
@@ -5,7 +5,7 @@
 
   --ds-card-height-percentage: 98%;
   --ds-card-thumbnail-height: 240px;
-  --ds-dropdown-menu-max-height: 200px;
+  --ds-dropdown-menu-max-height: 400px;
   --ds-drop-zone-area-height: 44px;
   --ds-drop-zone-area-z-index: 1025;
   --ds-drop-zone-area-inner-z-index: 1021;


### PR DESCRIPTION
## Description
We can now create components to render a custom search result.
In order to do that, a new decorator has been created which allows to define which component to use for which field.
If no component is defined for a field, use the DSpace default component.