### PR TITLE
[ADD] feat(submission-form): New cancel edit button + bad form status fix.

### DIFF
--- a/src/app/submission/form/footer/submission-form-footer.component.html
+++ b/src/app/submission/form/footer/submission-form-footer.component.html
@@ -9,6 +9,13 @@
             (click)="$event.preventDefault();confirmDiscard(content)">
       <i class="fas fa-trash"></i> {{'submission.general.discard.submit' | translate}}
     </button>
+    <button *ngIf="(showDepositAndDiscard | async) !== true"
+            type="button"
+            id="cancel"
+            class="btn btn-danger"
+            (click)="cancelEdit($event)">
+      <i class="fa-solid fa-circle-left"></i> {{ 'submission.general.edit.cancel' | translate }}
+    </button>
   </div>
   <div class="col text-right d-flex justify-content-end align-items-center">
     <span *ngIf="(hasUnsavedModification | async) !== true && (processingSaveStatus | async) !== true && (processingDepositStatus | async) !== true && (submissionIsInvalid | async)">
@@ -28,7 +35,7 @@
     </div>
     <div class="ml-2 space-children-mr">
       <button type="button"
-              class="btn btn-secondary"
+              class="btn btn-primary"
               id="save"
               [attr.data-test]="'save' | dsBrowserOnly"
               [dsBtnDisabled]="(processingSaveStatus | async) || (hasUnsavedModification | async) !== true"

--- a/src/app/submission/form/footer/submission-form-footer.component.ts
+++ b/src/app/submission/form/footer/submission-form-footer.component.ts
@@ -109,6 +109,10 @@ export class SubmissionFormFooterComponent implements OnChanges {
     this.submissionService.dispatchSaveForLater(this.submissionId);
   }
 
+  cancelEdit(event) {
+    this.submissionService.redirectToItemPage(this.submissionId);
+  }
+
   /**
    * Dispatch a submission deposit action
    */

--- a/src/app/submission/form/submission-form.component.scss
+++ b/src/app/submission/form/submission-form.component.scss
@@ -12,9 +12,10 @@
 .submission-form-footer {
   border-radius: var(--bs-card-border-radius);
   bottom: 0;
-  background-color: var(--bs-gray-400);
+  background-color: var(--bs-gray-100);
   padding: calc(var(--bs-spacer) / 2);
   z-index: var(--ds-submission-footer-z-index);
+  border: 1px solid var(--bs-card-border-color);
 }
 
 .btn-link-focus {

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -6567,6 +6567,8 @@
 
   "submission.general.cancel": "Cancel",
 
+  "submission.general.edit.cancel": "Back",
+
   "submission.general.cannot_submit": "You don't have permission to make a new submission.",
 
   "submission.general.deposit": "Deposit",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -6286,6 +6286,8 @@
   // "submission.general.cancel": "Cancel",
   "submission.general.cancel": "Annuler",
 
+  "submission.general.edit.cancel": "Retour",
+
   // "submission.general.cannot_submit": "You have not the privilege to make a new submission.",
   "submission.general.cannot_submit": "Vous n'avez pas les droits requis pour faire une nouvelle soumission.",
 


### PR DESCRIPTION
## Description

In some cases, the form sections where not considered valid even if all the fields where filled. Added a behavior in the type-bind logic to disable the controls of the hidden fields. This prevents the section form considering its status has 'not valid' because of hidden fields.

Also added a cancel button which allows to go back t the item page when editing and updated the overall style of the footer-bar.

BUG: When exiting the item edit page, you have to confirm 2 times before being able to exit.

## Preview
<img width="1920" height="927" alt="image" src="https://github.com/user-attachments/assets/55a7cc17-d98e-4e8f-943e-dfa199ae3876" />
