### PR TITLE
[UPD] feat(dropdown-field): Added an edit mode for the dropdown component.

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.html
@@ -17,14 +17,15 @@
            [class.scrollable-dropdown-input]="!model.readOnly"
            [id]="id"
            [name]="model.name"
-           [readonly]="true"
+           [readonly]="!model.editable"
            [disabled]="model.readOnly"
            [type]="model.inputType"
            [value]="(currentValue | async)"
            (blur)="onBlur($event)"
            (click)="$event.stopPropagation(); openDropdown(sdRef);"
            (focus)="onFocus($event)"
-           (keydown)="selectOnKeyDown($event, sdRef)">
+           (keydown)="selectOnKeyDown($event, sdRef)"
+           (input)="onInput($event)">
   </div>
 
   <div #dropdownMenu ngbDropdownMenu

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
@@ -68,6 +68,7 @@ import { VocabularyService } from '../../../../../../core/submission/vocabularie
 import {
   hasValue,
   isEmpty,
+  isNotEmpty,
 } from '../../../../../empty.util';
 import { FormFieldMetadataValueObject } from '../../../models/form-field-metadata-value.model';
 import { DsDynamicVocabularyComponent } from '../dynamic-vocabulary.component';
@@ -361,6 +362,13 @@ export class DsDynamicScrollableDropdownComponent extends DsDynamicVocabularyCom
         this.pageInfo.totalPages,
       );
       this.loadOptions(this.searchText, false, true, true);
+    }
+  }
+
+  onInput(event: any): void {
+    if (this.model.editable && isNotEmpty(event.target.value)) {
+      this.dispatchUpdate(event.target.value);
+      this.setCurrentValue(event.target.value);
     }
   }
 

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model.ts
@@ -35,17 +35,21 @@ export class DynamicScrollableDropdownModel extends DsDynamicInputModel {
    * Resource type to match data service
    */
   resourceType: ResourceType;
+  /** Wether or not the dropdown should be editable */
+  editable: boolean;
 
-  constructor(config: DynamicScrollableDropdownModelConfig, layout?: DynamicFormControlLayout) {
+  constructor(config: DynamicScrollableDropdownModelConfig, layout?: DynamicFormControlLayout, editable = false) {
 
     super(config, layout);
 
     this.autoComplete = AUTOCOMPLETE_OFF;
     this.vocabularyOptions = config.vocabularyOptions;
-    this.maxOptions = config.maxOptions || 10;
+    // DEV_NOTE: keep this option above 10: if 10: the list does not load entirely because of the on scroll system and the custom max-height.
+    this.maxOptions = config.maxOptions || 20;
     this.displayKey = config.displayKey || 'display';
     this.formatFunction = config.formatFunction;
     this.resourceType = config.resourceType;
+    this.editable = editable;
   }
 
 }

--- a/src/app/shared/form/builder/parsers/editable-dropdown-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/editable-dropdown-field-parser.ts
@@ -1,0 +1,36 @@
+import { DynamicFormControlLayout } from "@ng-dynamic-forms/core";
+import { FormFieldMetadataValueObject } from "../models/form-field-metadata-value.model";
+import { DropdownFieldParser } from "./dropdown-field-parser";
+import { isNotEmpty } from "src/app/shared/empty.util";
+import { DynamicScrollableDropdownModel, DynamicScrollableDropdownModelConfig } from "../ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model";
+
+/**
+ * Custom field parser for custom "editable" dropdown behavior.
+ * This is basically a clone of {@link DropdownFieldParser} which sets the 'editable' property to true.
+ * 
+ * @author Michaël Pourbaix <michael.pourbaix@uclouvain.be>
+ */
+export class EditableDropdownFieldParser extends DropdownFieldParser {
+
+  public modelFactory(fieldValue?: FormFieldMetadataValueObject, label?: boolean): any {
+    const dropdownModelConfig: DynamicScrollableDropdownModelConfig = this.initModel(null, label);
+    let layout: DynamicFormControlLayout;
+    console.log(this.configData);
+    if (isNotEmpty(this.configData.selectableMetadata[0].controlledVocabulary)) {
+      this.setVocabularyOptions(dropdownModelConfig, this.parserOptions.collectionUUID);
+      this.setValues(dropdownModelConfig, fieldValue, true);
+      layout = {
+        element: {
+          control: 'col',
+        },
+        grid: {
+          host: 'col',
+        },
+      };
+      const dropdownModel = new DynamicScrollableDropdownModel(dropdownModelConfig, layout, true);
+      return dropdownModel;
+    } else {
+      throw Error(`Controlled Vocabulary name is not available. Please check the form configuration file.`);
+    }
+  }
+}

--- a/src/app/shared/form/builder/parsers/parser-factory.ts
+++ b/src/app/shared/form/builder/parsers/parser-factory.ts
@@ -30,6 +30,7 @@ import { YearFieldParser } from './year-field-parser';
 import { HiddenFieldParser } from './hidden-field-parser';
 import { InstitutionAffiliationFieldParser } from './institution-affiliation-field-parser';
 import { DepartmentAffiliationFieldParser } from './department-affiliation-field-parser'
+import { EditableDropdownFieldParser } from './editable-dropdown-field-parser';
 
 const fieldParserDeps = [
   SUBMISSION_ID,
@@ -66,6 +67,13 @@ export class ParserFactory {
           useClass: DropdownFieldParser,
           deps: [...fieldParserDeps],
         };
+      }
+      case ParserType.EditableDropdown : {
+        return {
+          provide: FieldParser,
+          useClass: EditableDropdownFieldParser,
+          deps: [...fieldParserDeps]
+        }
       }
       case ParserType.RelationGroup:
       case ParserType.InlineGroup:

--- a/src/app/shared/form/builder/parsers/parser-type.ts
+++ b/src/app/shared/form/builder/parsers/parser-type.ts
@@ -1,6 +1,7 @@
 export enum ParserType {
   Date = 'date',
   Dropdown = 'dropdown',
+  EditableDropdown = 'editable-dropdown',
   RelationGroup = 'group',
   InlineGroup = 'inline-group',
   InlineLabeledGroup = 'inline-labeled-group',


### PR DESCRIPTION
## Description

A new parser creates a dropdown model with the 'editable' flag to true. When a dropdown component renders, it reads the flag to see if it should be editable. If a dropdown component is editable, the user can either select a value from the options or type a custom one.

Also fixed a case where all options would not render due to the custom 'max-height' and 'max-options' values.

