### PR TITLE
[ADD] feat(select-field): Possible default value for select.

### DIFF
--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
@@ -73,6 +73,7 @@ import {
 import { FormFieldMetadataValueObject } from '../../../models/form-field-metadata-value.model';
 import { DsDynamicVocabularyComponent } from '../dynamic-vocabulary.component';
 import { DynamicScrollableDropdownModel } from './dynamic-scrollable-dropdown.model';
+import { VocabularyEntry } from 'src/app/core/submission/vocabularies/models/vocabulary-entry.model';
 
 /**
  * Component representing a dropdown input field
@@ -232,8 +233,25 @@ export class DsDynamicScrollableDropdownComponent extends DsDynamicVocabularyCom
         list.pageInfo.totalPages,
       );
       this.selectedIndex = 0;
+      this.selectDefaultValue(this.model, this.optionsList);
       this.cdr.detectChanges();
     });
+  }
+
+  /**
+   * Select a default value for the dropdown if the setting is present in the configuration.
+   * If a 'defaultValue' is given (through config), try to find an option using that value and select it.
+   * if no matching option found or no 'defaultValue' setting, select the first option.
+   * 
+   * @param model The current field model.
+   * @param optionsList The list of options 
+   */
+  selectDefaultValue(model: DynamicScrollableDropdownModel, optionsList: CacheableObject[]) {
+    if (!model.useDefaultValue || model.value || !optionsList?.length) {
+      return;
+    }
+    const selectedEntry = optionsList.find((entry: VocabularyEntry) => entry.value === model.defaultValue) || optionsList[0];
+    this.onSelect(selectedEntry);
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.model.ts
@@ -21,6 +21,8 @@ export interface DynamicScrollableDropdownModelConfig extends DsDynamicInputMode
   formatFunction?: (value: any) => string;
   resourceType?: ResourceType;
   editable?: boolean;
+  useDefaultValue?: boolean;
+  defaultValue?: string;
 }
 
 export class DynamicScrollableDropdownModel extends DsDynamicInputModel {
@@ -38,6 +40,10 @@ export class DynamicScrollableDropdownModel extends DsDynamicInputModel {
   resourceType: ResourceType;
   /** Wether or not the dropdown should be editable */
   editable: boolean;
+  /** If we should use a default value or not for this field */
+  useDefaultValue: boolean;
+  /** If a default value has to be set, this indicate the value to set (must exist in vocabulary options). */
+  defaultValue: string;
 
   constructor(config: DynamicScrollableDropdownModelConfig, layout?: DynamicFormControlLayout) {
 
@@ -51,6 +57,8 @@ export class DynamicScrollableDropdownModel extends DsDynamicInputModel {
     this.formatFunction = config.formatFunction;
     this.resourceType = config.resourceType;
     this.editable = config.editable;
+    this.useDefaultValue = config?.useDefaultValue;
+    this.defaultValue = config?.defaultValue;
   }
 
 }

--- a/src/app/shared/form/builder/parsers/dropdown-field-parser.ts
+++ b/src/app/shared/form/builder/parsers/dropdown-field-parser.ts
@@ -38,6 +38,8 @@ export class DropdownFieldParser extends FieldParser {
     let layout: DynamicFormControlLayout;
 
     dropdownModelConfig.editable = getSetting(this.configData, 'editable', Boolean) ?? false;
+    dropdownModelConfig.useDefaultValue = getSetting(this.configData, 'useDefault', Boolean) ?? false;
+    dropdownModelConfig.defaultValue = getSetting(this.configData, 'defaultValue', String);
 
     if (isNotEmpty(this.configData.selectableMetadata[0].controlledVocabulary)) {
       this.setVocabularyOptions(dropdownModelConfig, this.parserOptions.collectionUUID);


### PR DESCRIPTION
It is now possible to add a default value for select fields.
We have two new settings: 'hasDefault' and 'defaultValue'.
If 'hasDefault' is true then we must select a default value for the field.
If 'defaultValue' is set, we use the provided option as default, or else we use the first available option as default.

See backend for configuration.

Authored-by: Michaël Pourbaix <michael.pourbaix@uclouvain.be>

