### PR TITLE
[UPD] feat(default-value): Fixed error due to default value of select.

### DIFF
--- a/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission-dropdown/my-dspace-new-submission-dropdown.component.ts
+++ b/src/app/my-dspace-page/my-dspace-new-submission/my-dspace-new-submission-dropdown/my-dspace-new-submission-dropdown.component.ts
@@ -16,7 +16,7 @@ import { BtnDisabledDirective } from '../../../shared/btn-disabled.directive';
 import {
   ThemedCreateItemParentSelectorComponent
 } from '../../../shared/dso-selector/modal-wrappers/create-item-parent-selector/themed-create-item-parent-selector.component';
-import { hasValue } from '../../../shared/empty.util';
+import { hasValue, isNotEmpty } from '../../../shared/empty.util';
 import { EntityDropdownComponent } from '../../../shared/entity-dropdown/entity-dropdown.component';
 import { BrowserOnlyPipe } from '../../../shared/utils/browser-only.pipe';
 
@@ -125,7 +125,7 @@ export class MyDSpaceNewSubmissionDropdownComponent implements OnInit, OnDestroy
    */
   openDialog(entity: ItemType) {
     const modalRef = this.modalService.open(ThemedCreateItemParentSelectorComponent, { size: 'xl', backdrop: 'static' });
-    modalRef.componentInstance.entityType = entity.label;
+    if (isNotEmpty(entity)) modalRef.componentInstance.entityType = entity.label;
   }
 
   /**

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-form-control-container.component.ts
@@ -373,7 +373,11 @@ export class DsDynamicFormControlContainerComponent extends DynamicFormControlCo
       const control = this.formBuilderService.getFormControlByModel(this.formGroup, this.model) as FormControl;
       if (control) {
         this.subs.push(control.valueChanges
-          .subscribe(value => this.isLinkedToAuthority = Object.prototype.hasOwnProperty.call(value, 'authority') && isNotEmpty(value.authority)));
+          .subscribe(value => {
+            if (isNotEmpty(value)) {
+              this.isLinkedToAuthority = Object.prototype.hasOwnProperty.call(value, 'authority') && isNotEmpty(value.authority);
+            }
+          }));
       }
     }
     this.showErrorMessagesPreviousStage = this.showErrorMessages;

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/ds-dynamic-type-bind-relation.service.ts
@@ -261,9 +261,11 @@ export class DsDynamicTypeBindRelationService {
                   // This is necessary in order to not take hidden field into account when validating a form.
                   if (hasMatch && control.enabled) {
                     control.setErrors(null);
-                    control.disable({emitEvent: false});
+                    // Emit event to allow other component to react to the type-bind changes.
+                    control.disable({emitEvent: true});
                   } else if (!hasMatch && control.disabled) {
-                    control.enable({emitEvent: false});
+                    // Emit event to allow other component to react to the type-bind changes.
+                    control.enable({emitEvent: true});
                   }
                   // Make sure to update the trigger an update of validity.
                   control?.parent?.updateValueAndValidity({ onlySelf: false, emitEvent: false });

--- a/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
+++ b/src/app/shared/form/builder/ds-dynamic-form-ui/models/scrollable-dropdown/dynamic-scrollable-dropdown.component.ts
@@ -179,6 +179,7 @@ export class DsDynamicScrollableDropdownComponent extends DsDynamicVocabularyCom
       .subscribe((value) => {
         this.setCurrentValue(value, true);
       });
+    this.control.statusChanges.subscribe(() => this.selectDefaultValue(this.model, this.optionsList));
     this.initFilterSubscriber();
   }
 
@@ -247,7 +248,12 @@ export class DsDynamicScrollableDropdownComponent extends DsDynamicVocabularyCom
    * @param optionsList The list of options 
    */
   selectDefaultValue(model: DynamicScrollableDropdownModel, optionsList: CacheableObject[]) {
-    if (!model.useDefaultValue || model.value || !optionsList?.length) {
+    // Cancel select of default value if:
+    //  - The configuration does not enable default value,
+    //  - The model already has a value,
+    //  - There are no option available,
+    //  - The control is undefined or disabled
+    if (!model.useDefaultValue || model.value || !optionsList?.length || !this.control || this.control.disabled) {
       return;
     }
     const selectedEntry = optionsList.find((entry: VocabularyEntry) => entry.value === model.defaultValue) || optionsList[0];


### PR DESCRIPTION
## Description

When a select field was type-bind hidden, it still added a default value to the select field. This triggered a patch on the metadata and the backend cleaned the values because the field is type-bind hidden. After that, it was not possible to set a value for the field once visible: an error was thrown. Now, select fields cannot have a default values if they are hidden.

