### PR TITLE
[FIX] feat(request-copy): Resolved 403 error when requesting a copy on restricted access.

### DIFF
--- a/src/app/core/data/feature-authorization/feature-id.ts
+++ b/src/app/core/data/feature-authorization/feature-id.ts
@@ -49,4 +49,5 @@ export enum FeatureID {
   CanSeeComment = 'canSeeComment',
   CanCreateComment = 'canCreateComment',
   CanDeleteComment = 'canDeleteComment',
+  HasAuthorEmail = 'hasAuthorEmail',
 }

--- a/src/app/shared/file-download-link/file-download-link.component.ts
+++ b/src/app/shared/file-download-link/file-download-link.component.ts
@@ -10,7 +10,7 @@ import {
   OnInit,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import {
   combineLatest as observableCombineLatest,
   Observable,
@@ -85,6 +85,8 @@ export class FileDownloadLinkComponent implements OnInit {
   }>;
 
   canDownload$: Observable<boolean>;
+  canRequestACopy$: Observable<boolean>;
+  noAccess$: Observable<boolean>;
 
   /**
    * Whether or not the user can request a copy of the item
@@ -97,14 +99,17 @@ export class FileDownloadLinkComponent implements OnInit {
     private authorizationService: AuthorizationDataService,
     private configurationService: ConfigurationDataService,
     public dsoNameService: DSONameService,
+    private translateService: TranslateService,
   ) {
   }
 
   ngOnInit() {
     if (this.enableRequestACopy) {
       this.canDownload$ = this.authorizationService.isAuthorized(FeatureID.CanDownload, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
-      const canRequestACopy$ = this.authorizationService.isAuthorized(FeatureID.CanRequestACopy, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
-      this.bitstreamPath$ = observableCombineLatest([this.canDownload$, canRequestACopy$]).pipe(
+      this.canRequestACopy$ = this.authorizationService.isAuthorized(FeatureID.CanRequestACopy, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
+      this.noAccess$ = observableCombineLatest([this.canDownload$, this.canRequestACopy$])
+        .pipe(map(([canDownload, canRequestACopy]) => !canDownload && !canRequestACopy));
+      this.bitstreamPath$ = observableCombineLatest([this.canDownload$, this.canRequestACopy$]).pipe(
         map(([canDownload, canRequestACopy]) => this.getBitstreamPath(canDownload, canRequestACopy)),
       );
 
@@ -137,5 +142,15 @@ export class FileDownloadLinkComponent implements OnInit {
       routerLink: getBitstreamDownloadRoute(this.bitstream),
       queryParams: {},
     };
+  }
+
+  getNoAccessExplanation(): Observable<String> {
+    let hasAuthorEmail$ = this.authorizationService.isAuthorized(FeatureID.HasAuthorEmail, isNotEmpty(this.bitstream) ? this.bitstream.self : undefined);
+    return observableCombineLatest([hasAuthorEmail$]).pipe(map(([hasAuthorEmail]) => {
+      if (!hasAuthorEmail) {
+        return this.translateService.instant('item.page.filesection.no-access.explanation.no-email');
+      }
+      return this.translateService.instant('item.page.filesection.no-access.explanation.generic');
+    }))
   }
 }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -3738,6 +3738,8 @@
   "item.page.filesection.download": "Download",
   "item.page.filesection.request-a-copy": "Request a copy",
   "item.page.filesection.no-access": "No access",
+  "item.page.filesection.no-access.explanation.no-email": "This file cannot be downloaded. The request copy is not available because no author email is provided for this publication.",
+  "item.page.filesection.no-access.explanation.generic": "This file cannot be downloaded. For an unknown reason, the request copy is not available for this publication.",
   "item.page.filesection.format": "Format:",
 
   "item.page.filesection.name": "Name:",

--- a/src/assets/i18n/fr.json5
+++ b/src/assets/i18n/fr.json5
@@ -4082,6 +4082,8 @@
   "item.page.filesection.download": "Télécharger",
   "item.page.filesection.request-a-copy": "Demander un accès",
   "item.page.filesection.no-access": "Aucun accès",
+  "item.page.filesection.no-access.explanation.no-email": "Ce fichier ne peut pas être téléchargé. La demande de copie est indisponible car aucun email d'auteur n'est fourni pour cette publication.",
+  "item.page.filesection.no-access.explanation.generic": "Ce fichier ne peut pas être téléchargé. Pour une raison inconue, la demande de copie est indisponible pour cette publication.",
 
   // "item.page.filesection.format": "Format:",
   "item.page.filesection.format": "Format:",

--- a/src/themes/uclouvain/app/item-page/full/field-components/file-section/upload-file-description/upload-file-description.component.html
+++ b/src/themes/uclouvain/app/item-page/full/field-components/file-section/upload-file-description/upload-file-description.component.html
@@ -30,7 +30,7 @@
       </ul>
     </div>
   </div>
-  <div class="ml-auto d-flex flex-column align-items-end justify-content-start text-nowrap">
+  <div class="ml-auto d-flex flex-column align-items-end justify-content-center text-nowrap">
     <ds-file-download-link *ngIf="!hasNoDownload()"
                            [bitstream]="bitstream"
                            [item]="item"

--- a/src/themes/uclouvain/app/shared/file-download-link/file-download-link.component.html
+++ b/src/themes/uclouvain/app/shared/file-download-link/file-download-link.component.html
@@ -1,23 +1,27 @@
-<a [ngbTooltip]="'item.page.filesection.download' | translate"
-   [routerLink]="(bitstreamPath$| async)?.routerLink"
-   [queryParams]="(bitstreamPath$| async)?.queryParams"
+<a [ngbTooltip]="(noAccess$ | async) ? (getNoAccessExplanation() | async) : ('item.page.filesection.download' | translate)"
+   [routerLink]="(noAccess$ | async) ? null : (bitstreamPath$ | async)?.routerLink" 
    class="dont-break-out"
+   [queryParams]="(noAccess$ | async) ? null : (bitstreamPath$ | async)?.queryParams"
    [target]="isBlank ? '_blank': '_self'"
-   [ngClass]="cssClasses">
-    <ng-container *ngIf="canDownload$ | async">
-        <i *ngIf="showIcon" class="fas fa-download pr-1"></i>
-        <span *ngIf="showText" class="mr-1">{{ "item.page.filesection.download" | translate }}</span>
-    </ng-container>
-    <ng-container *ngIf="!(canDownload$ | async)">
-        <i *ngIf="showIcon" class="fas fa-lock pr-1"></i>
-        <ng-container *ngIf="showText">
-            <ng-container *ngIf="(canRequestItemCopy$ | async)">{{ "item.page.filesection.request-a-copy" | translate }}</ng-container>
-            <ng-container *ngIf="!(canRequestItemCopy$ | async)">{{ "item.page.filesection.no-access" | translate }}</ng-container>
-        </ng-container>
-    </ng-container>
-    <ng-container *ngTemplateOutlet="content"></ng-container>
+   [ngClass]="cssClasses"
+   [attr.aria-disabled]="(noAccess$ | async) ? 'true' : null"
+   [attr.aria-label]="('file-download-link.download' | translate) + dsoNameService.getName(bitstream)">
+
+  <ng-container *ngIf="canDownload$ | async">
+    <i *ngIf="showIcon" class="fas fa-download pr-1"></i>
+    <span *ngIf="showText" class="mr-1">{{ "item.page.filesection.download" | translate }}</span>
+  </ng-container>
+  <ng-container *ngIf="canRequestACopy$ | async">
+    <i *ngIf="showIcon" class="fas fa-lock pr-1"></i>
+    <span *ngIf="showText" class="mr-1">{{ "item.page.filesection.request-a-copy" | translate }}</span>
+  </ng-container>
+  <ng-container *ngIf="noAccess$ | async">
+    <i *ngIf="showIcon" class="fas fa-lock pr-1"></i>
+    <span *ngIf="showText" class="mr-1">{{ 'item.page.filesection.no-access' | translate }}</span>
+  </ng-container>
+  <ng-container *ngTemplateOutlet="content"></ng-container>
 </a>
 
 <ng-template #content>
-    <ng-content></ng-content>
+  <ng-content></ng-content>
 </ng-template>


### PR DESCRIPTION
## Description

Added a new behavior for the 'download' button of bitstreams. When no author is provided for a given publication, no request of copy can be done. In this case, we display a 'no-access' button with some explanation tooltip.

<img width="962" height="304" alt="image" src="https://github.com/user-attachments/assets/90c98c5e-ccb4-4482-9560-7f135d8624fe" />


this fixes #324

